### PR TITLE
LPS-142935

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -145,6 +145,28 @@
     #
     upgrade.report.enabled=false
 
+    #
+    # Set the fetch size of the result set for statements used during upgrade.
+    # Larger values will result in less network requests to the database and
+    # speed up the upgrade process at the cost of keeping more results in the
+    # memory at a time.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_JDBC_PERIOD_RESULT_PERIOD_SET_PERIOD_FETCH_PERIOD_SIZE
+    #
+    upgrade.jdbc.result.set.fetch.size=1000
+
+    #
+    # Set the max size of the future list before which the upgrade process will
+    # stop to clear it. This future list is used to store task references that
+    # are run in parallel in long running upgrades. Setting it to a value too
+    # high will make the upgrade process keep more objects from being garbage
+    # collected for a longer time, which may produce high memory usage and
+    # potentially OutOfMemoryErrors.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_CONCURRENT_PERIOD_PROCESS_PERIOD_LIST_PERIOD_MAX_PERIOD_SIZE
+    #
+    upgrade.concurrent.process.list.max.size=1000
+
 ##
 ## Verify
 ##

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -3365,11 +3365,17 @@ public interface PropsKeys {
 	public static final String UNICODE_TEXT_NORMALIZER_FORM =
 		"unicode.text.normalizer.form";
 
+	public static final String UPGRADE_CONCURRENT_PROCESS_FUTURE_LIST_MAX_SIZE =
+		"upgrade.concurrent.process.list.max.size";
+
 	public static final String UPGRADE_DATABASE_AUTO_RUN =
 		"upgrade.database.auto.run";
 
 	public static final String UPGRADE_DATABASE_TRANSACTIONS_DISABLED =
 		"upgrade.database.transactions.disabled";
+
+	public static final String UPGRADE_JDBC_RESULT_SET_FETCH_SIZE =
+		"upgrade.jdbc.result.set.fetch.size";
 
 	public static final String UPGRADE_REPORT_ENABLED =
 		"upgrade.report.enabled";


### PR DESCRIPTION
Relevante issue: https://issues.liferay.com/browse/LPS-142935

When trying to upgrade from 7.1 to 7.4 some issues happen with upgrade process `com.liferay.journal.internal.upgrade.v4_0_0.JournalArticleDDMFieldsUpgradeProcess` using MySQL.

Analyzing a heap dump generated automatically when an OutOfMemoryError occurs, we've confirmed 8GB of the heap is consumed by a single ResultSet that is holding a massive amount of JournalArticle rows (roughly 200,000).

We've seen that this is the expected behavior for the MySQL JDBC connector, according to the [JDBC API Implementation Notes article](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-implementation-notes.html). The driver will retrieve all rows at once by default unless the query string has a specific parameter and the fetch size is explicitly set.

The fix will consist of limiting the fetch size for the ResultSet used in upgrade (default value 1000).

Also, I've found that despite the fetch size, the `Future` objects are accumulated in an array list until the end of the processing of all results, which also cause the heap size to grow unnecessarily (the `Future` objects will return nothing, so we just call `get()` on all of them at the end). The solution is to clear the array list every time its size reaches a given threshold (default value 1000).