### PR TITLE
LPS-144203 Leftover data from Software Catalog module after Data Cleanup

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/SoftwareCatalogUpgradeProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/SoftwareCatalogUpgradeProcess.java
@@ -44,7 +44,9 @@ public class SoftwareCatalogUpgradeProcess extends BaseUpgradeProcess {
 		_deleteImages();
 		_deleteSocial();
 
-		removePortletData(null, null, new String[] {"98"});
+		removePortletData(
+			null, null,
+			new String[] {"98", "com.liferay.portlet.softwarecatalog"});
 
 		removeServiceData(
 			null, new String[] {"com.liferay.softwarecatalog.service"},


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-144203>

__Notes:__
Relatively straightforward. We were missing one of the portlet IDs from the Software Catalog module.

Let me know if you have any questions.