### PR TITLE
LPS-145056 We only need to know if the preferences column has somethi…

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradePortletPreferences.java
@@ -50,10 +50,9 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 			SQLTransformer.transform(
 				StringBundler.concat(
 					"select ctCollectionId, portletPreferencesId, companyId, ",
-					"preferences from PortletPreferences where ",
-					"CAST_CLOB_TEXT(preferences) != '",
-					PortletConstants.DEFAULT_PREFERENCES,
-					"' and preferences is not null")),
+					"preferences from PortletPreferences where preferences ",
+					"not like '", PortletConstants.DEFAULT_PREFERENCES,
+					"%' and preferences is not null")),
 			resultSet -> new Object[] {
 				resultSet.getLong("ctCollectionId"),
 				resultSet.getLong("portletPreferencesId"),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145056

resending based on comment here: https://github.com/liferay-upgrades/liferay-portal/pull/211#issuecomment-1010089024

Regarding the 2 options:

**Option 1**
Our sql transformers are not smart enough to wrap functions within one another.

When passing in this query:

"select ctCollectionId, portletPreferencesId, companyId, preferences from PortletPreferences where CAST_CLOB_TEXT(SUBSTR(preferences, 0, 23)) != '<portlet-preferences />' and preferences is not null"));""

The CAST_CLOB_TEXT(SUBSTR(preferences, 0, 23)) is evaluated to DBMS_LOB.SUBSTR(SUBSTR(preferences, 0, 23, 4000, 1)) which does not run at all due to the functions being the wrong number of arguments. If I remove the CAST_CLOB_TEXT and use only SUBSTR the query fails with the following error: "Caused by: java.sql.SQLSyntaxErrorException: ORA-00932: inconsistent datatypes: expected - got CLOB" because we are trying to evaluate something in the data in the query rather than just returning a value.

**Option 2**
Does work and is what I am submitting here, but I do worry about the possible performance impacts on databases that may not optimize like you suggested in your comment. I believe Oracle will optimize, but I am not certain about the others. The sql itself is valid on all of the databases we support though.