### PR TITLE
LPS-135352 buildUpgradeTable

### DIFF
--- a/modules/apps/journal/journal-service/bnd.bnd
+++ b/modules/apps/journal/journal-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Service
 Bundle-SymbolicName: com.liferay.journal.service
 Bundle-Version: 7.0.43
-Liferay-Require-SchemaVersion: 4.1.0
+Liferay-Require-SchemaVersion: 4.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
@@ -61,6 +61,7 @@ import com.liferay.journal.internal.upgrade.v3_5_0.JournalArticleContentUpgradeP
 import com.liferay.journal.internal.upgrade.v3_5_1.JournalArticleDataFileEntryIdUpgradeProcess;
 import com.liferay.journal.internal.upgrade.v4_0_0.JournalArticleDDMFieldsUpgradeProcess;
 import com.liferay.journal.internal.upgrade.v4_1_0.JournalArticleExternalReferenceCodeUpgradeProcess;
+import com.liferay.journal.internal.upgrade.v4_2_0.JournalFeedUpgradeProcess;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.portal.change.tracking.store.CTStoreFactory;
@@ -303,6 +304,8 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"4.0.0", "4.1.0",
 			new JournalArticleExternalReferenceCodeUpgradeProcess());
+
+		registry.register("4.1.0", "4.2.0", new JournalFeedUpgradeProcess());
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_2_0/JournalFeedUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_2_0/JournalFeedUpgradeProcess.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.upgrade.v4_2_0;
+
+import com.liferay.journal.internal.upgrade.v4_2_0.util.JournalFeedTable;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class JournalFeedUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		alter(
+			JournalFeedTable.class,
+			new AlterColumnType("DDMStructureKey", "VARCHAR(75) null"),
+			new AlterColumnType("DDMTemplateKey", "VARCHAR(75) null"),
+			new AlterColumnType("DDMRendererTemplateKey", "VARCHAR(75) null"));
+	}
+
+}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_2_0/util/JournalFeedTable.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_2_0/util/JournalFeedTable.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.upgrade.v4_2_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class JournalFeedTable {
+
+	public static final String TABLE_NAME = "JournalFeed";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
+		{"uuid_", Types.VARCHAR}, {"id_", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"feedId", Types.VARCHAR}, {"name", Types.VARCHAR},
+		{"description", Types.VARCHAR}, {"DDMStructureKey", Types.VARCHAR},
+		{"DDMTemplateKey", Types.VARCHAR},
+		{"DDMRendererTemplateKey", Types.VARCHAR}, {"delta", Types.INTEGER},
+		{"orderByCol", Types.VARCHAR}, {"orderByType", Types.VARCHAR},
+		{"targetLayoutFriendlyUrl", Types.VARCHAR},
+		{"targetPortletId", Types.VARCHAR}, {"contentField", Types.VARCHAR},
+		{"feedFormat", Types.VARCHAR}, {"feedVersion", Types.DOUBLE},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("id_", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("feedId", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("DDMStructureKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("DDMTemplateKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("DDMRendererTemplateKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("delta", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("orderByCol", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("orderByType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("targetLayoutFriendlyUrl", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("targetPortletId", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("contentField", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("feedFormat", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("feedVersion", Types.DOUBLE);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table JournalFeed (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,id_ LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,feedId VARCHAR(75) null,name VARCHAR(75) null,description STRING null,DDMStructureKey VARCHAR(75) null,DDMTemplateKey VARCHAR(75) null,DDMRendererTemplateKey VARCHAR(75) null,delta INTEGER,orderByCol VARCHAR(75) null,orderByType VARCHAR(75) null,targetLayoutFriendlyUrl VARCHAR(255) null,targetPortletId VARCHAR(200) null,contentField VARCHAR(75) null,feedFormat VARCHAR(75) null,feedVersion DOUBLE,lastPublishDate DATE null,primary key (id_, ctCollectionId))";
+
+	public static final String TABLE_SQL_DROP = "drop table JournalFeed";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_6727738D on JournalFeed (groupId, ctCollectionId)",
+		"create unique index IX_53294B1A on JournalFeed (groupId, feedId[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_A134796D on JournalFeed (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId)",
+		"create index IX_73FE31D7 on JournalFeed (uuid_[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create unique index IX_800F33AF on JournalFeed (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId)"
+	};
+
+}


### PR DESCRIPTION
Motivation
=======
The values for types in database for DDMRendererTemplateKey, DDMStructureKey and DDMTemplateKey are different for a version previous 7.x and master.

Upgraded database previous 7.X
```
DDMRendererTemplateKey longtext
DDMStructureKey longtext
DDMTemplateKey longtext
```

Fresh master database
```
DDMRendererTemplateKey varchar(75) DEFAULT NULL
DDMStructureKey varchar(75) DEFAULT NULL
DDMTemplateKey varchar(75) DEFAULT NULL
```

[Link to the issue](https://issues.liferay.com/browse/LPS-135352) 

Proposed Solution
========
Adds a new upgrade process to update the types of DDMRendererTemplateKey, DDMStructureKey and DDMTemplateKey to the value that we have in master.

Steps to Verify
========
1. Start a Liferay 6.2.x
2. Upgrade this database to Master (with DXP profile) -> tools/portal-tools-db-upgrade-client/db_upgrade.sh
4. Connect Master to a different, empty database schema
5. Start master against blank database schema
6. Compare JournalFeed tables between upgraded and fresh database
