### PR TITLE
Lpd 48693

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/imports.txt
+++ b/modules/util/source-formatter/src/main/resources/dependencies/imports.txt
@@ -57,6 +57,7 @@ com.liferay.bookmarks.model.BookmarksFolderConstants=com.liferay.bookmarks.const
 com.liferay.calendar.model.CalendarBookingConstants=com.liferay.calendar.constants.CalendarBookingConstants
 com.liferay.calendar.model.CalendarNotificationTemplateConstants=com.liferay.calendar.constants.CalendarNotificationTemplateConstants
 com.liferay.calendar.workflow.CalendarBookingWorkflowConstants=com.liferay.calendar.workflow.constants.CalendarBookingWorkflowConstants
+com.liferay.commerce.account.constants.CommerceAccountConstants=com.liferay.account.constants.AccountConstants
 com.liferay.commerce.account.constants.CommerceAccountPortletKeys=com.liferay.account.constants.AccountPortletKeys
 com.liferay.commerce.account.model.CommerceAccount=com.liferay.account.model.AccountEntry
 com.liferay.commerce.account.model.CommerceAccountGroup=com.liferay.account.model.AccountGroup

--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3676,6 +3676,33 @@
 		"to": "addOrUpdateCPAttachmentFileEntry(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#, param#12#, param#13#, param#14#, param#15#, param#16#, param#17#, param#18#, param#19#, true, param#20#, param#21#, param#22#, param#23#, param#24#)"
 	},
 	{
+		"from": "AccountConstants.ACCOUNT_TYPE_BUSINESS",
+		"issueKey": "LPD-48783",
+		"to": "AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS",
+		"validExtensions": [
+			"java",
+			"jsp"
+		]
+	},
+	{
+		"from": "AccountConstants.ACCOUNT_TYPE_GUEST",
+		"issueKey": "LPD-48783",
+		"to": "AccountConstants.ACCOUNT_ENTRY_TYPE_GUEST",
+		"validExtensions": [
+			"java",
+			"jsp"
+		]
+	},
+	{
+		"from": "AccountConstants.ACCOUNT_TYPE_PERSONAL",
+		"issueKey": "LPD-48783",
+		"to": "AccountConstants.ACCOUNT_ENTRY_TYPE_PERSON",
+		"validExtensions": [
+			"java",
+			"jsp"
+		]
+	},
+	{
 		"classNames": [
 			"DLFileEntryLocalService",
 			"DLFileEntryLocalServiceUtil"

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_48783.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_48783.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_48783 {
+
+	public void method() {
+		AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS;
+		AccountConstants.ACCOUNT_ENTRY_TYPE_GUEST;
+		AccountConstants.ACCOUNT_ENTRY_TYPE_PERSON;
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_48783.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_48783.testjsp
@@ -1,0 +1,12 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS;
+AccountConstants.ACCOUNT_ENTRY_TYPE_GUEST;
+AccountConstants.ACCOUNT_ENTRY_TYPE_PERSON;
+%>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_48783.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_48783.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_48783 {
+
+	public void method() {
+		AccountConstants.ACCOUNT_TYPE_BUSINESS;
+		AccountConstants.ACCOUNT_TYPE_GUEST;
+		AccountConstants.ACCOUNT_TYPE_PERSONAL;
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_48783.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_48783.testjsp
@@ -1,0 +1,12 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+AccountConstants.ACCOUNT_TYPE_BUSINESS;
+AccountConstants.ACCOUNT_TYPE_GUEST;
+AccountConstants.ACCOUNT_TYPE_PERSONAL;
+%>


### PR DESCRIPTION
ticket: https://liferay.atlassian.net/browse/LPD-48783

All of the constants from `CommerceAccountConstants` have been moved to `AccountConstants`, but their names have changed, so we need to catch those specific cases: [see here](https://github.com/liferay/liferay-portal/commit/71e4f922c682b9655edb5f343e416204e99991f2#diff-c5d40fdbf51c33f8e328d5a3705b2bcf395c15eab0a8f8855f3cd303cadc594bR426)