### PR TITLE
LPD-27585 | Automation removed liferay dependencies but did not add the "release.dxp.api" dependency in some cases

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDXPCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDXPCheck.java
@@ -77,11 +77,13 @@ public class GradleUpgradeReleaseDXPCheck extends BaseFileCheck {
 			Set<String> names = releaseDXPDependencies.get(
 				gradleDependency.getGroup());
 
-			if ((names != null) && names.contains(gradleDependency.getName())) {
+			if ((names == null) ||
+				!names.contains(gradleDependency.getName())) {
+
+				iterator.remove();
+
 				continue;
 			}
-
-			iterator.remove();
 
 			String configuration = gradleDependency.getConfiguration();
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/GradleUpgradeReleaseDxpCheck.testgradle
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/GradleUpgradeReleaseDxpCheck.testgradle
@@ -2,6 +2,8 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u27"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 
+	cssBuilder group: "com.liferay", name: "com.liferay.css.builder", version: "3.1.4"
+
 	testImplementation group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u27"
 	testImplementation group: "junit", name: "junit", version: "4.12"
 	testImplementation group: "org.mockito", name: "mockito-all", version: "1.10.19"

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/GradleUpgradeReleaseDxpCheck.testgradle
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/GradleUpgradeReleaseDxpCheck.testgradle
@@ -3,6 +3,8 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u27"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 
+	cssBuilder group: "com.liferay", name: "com.liferay.css.builder", version: "3.1.4"
+
 	testImplementation group: "com.liferay.portal", name: "release.dxp.api", version: "7.4.13.u27"
 	testImplementation group: "junit", name: "junit", version: "4.12"
 	testImplementation group: "org.mockito", name: "mockito-all", version: "1.10.19"


### PR DESCRIPTION
ticket: https://liferay.atlassian.net/browse/LPD-27585