### PR TITLE
LPD-47901 | SF Automation

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaBasePanelAppExtendedClassesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaBasePanelAppExtendedClassesCheck.java
@@ -41,14 +41,16 @@ public class UpgradeJavaBasePanelAppExtendedClassesCheck
 				StringBundler.concat(
 					matcher.group(1),
 					"\n\t)\n\tprivate Portlet _portlet;\n\n\t@Override\n\t",
-					"public Portlet getPortlet() {\n\t\treturn _portlet;"));
+					"public Portlet getPortlet() {\n\t\treturn _portlet;",
+					"\n\t}"));
 		}
 
 		return content;
 	}
 
 	private static final Pattern _setPortletPattern = Pattern.compile(
-		"(?:@Override\\s*|)(@Reference\\(\\s*.+\\s*\\)+\")[\\s+\\S+]+" +
-			"setPortlet[\\s+\\S+]+;");
+		"(?:@Override\\s*|)?(@Reference\\([\\s\\S]*?\"\\)\")[\\s\\S]*?" +
+			"\\)\\s*public\\s+void\\s+setPortlet\\s*\\([^)]*\\)\\s*\\" +
+				"{[\\s\\S]*?\\}");
 
 }

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaBasePanelAppExtendedClassesCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaBasePanelAppExtendedClassesCheck.testjava
@@ -17,4 +17,8 @@ public class UpgradeJavaBasePanelAppExtendedClassesCheck extends BasePanelApp {
 		return _portlet;
 	}
 
+	public String getLabel(Locale locale) {
+		return "Test";
+	}
+
 }

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaBasePanelAppExtendedClassesCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaBasePanelAppExtendedClassesCheck.testjava
@@ -16,4 +16,8 @@ public class UpgradeJavaBasePanelAppExtendedClassesCheck extends BasePanelApp {
 		super.setPortlet(portlet);
 	}
 
+	public String getLabel(Locale locale) {
+		return "Test";
+	}
+
 }


### PR DESCRIPTION
ticket: https://liferay.atlassian.net/browse/LPD-47901

A possible fix would be to simply change the regex pattern to catch up to the first semicolon, the current regex catches everything between the @ Override and the last semicolon in the code.

current regex: `(?:@ Override\s*|)(@ Reference\(\s*.+\s*\)+")[\s+\S+]+setPortlet[\s+\S+]+;`

```
@Override
	@Reference(
		target = "(javax.portlet.name=" + CacheManagementPortletKeys.CACHE_MANAGEMENT_PORTLET + ")",
		unbind = "-"
	)
	public void setPortlet(Portlet portlet) {
		super.setPortlet(portlet);
	}
	
	public String getLabel(Locale locale) {
		return "Test";
```

new regex: `(?:@ Override\s*|)(@ Reference\(\s*.+\s*\)+")[\s+\S+]+setPortlet[\s+\S+]+?;`

```
	@Override
	@Reference(
		target = "(javax.portlet.name=" + CacheManagementPortletKeys.CACHE_MANAGEMENT_PORTLET + ")",
		unbind = "-"
	)
	public void setPortlet(Portlet portlet) {
		super.setPortlet(portlet);
```