### PR TITLE
LPD-48765 Add replacement and test cases for accountEntry.getType() == CommerceAccountConstants.ACCOUNT_TYPE_PERSONAL usage to AccountEntry::isPersonalAccount

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -4012,6 +4012,14 @@
 		"to": "addOrUpdateCPAttachmentFileEntry(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#, param#12#, param#13#, param#14#, param#15#, param#16#, param#17#, param#18#, param#19#, true, param#20#, param#21#, param#22#, param#23#, param#24#)"
 	},
 	{
+		"classNames": [
+			"AccountEntry"
+		],
+		"from": "regex:(?<variableName>\\w+)\\s*\\.\\s*getType\\s*\\(\\s*\\)\\s*==\\s*CommerceAccountConstants\\s*\\.\\s*ACCOUNT_TYPE_PERSONAL",
+		"issueKey": "LPD-48765",
+		"to": "${variableName}.isPersonalAccount()"
+	},
+	{
 		"from": "ZipWriterFactory.getZipWriter",
 		"issueKey": "LPD-48770",
 		"newReference": "ZipWriterFactory _zipWriterFactory",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_48765.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_48765.testjava
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Wilson Ferreira
+ */
+public class LPD_48765 {
+	public AccountEntry method(AccountEntry accountEntry) {
+		if (accountEntry.isPersonalAccount()) {
+			return accountEntry;
+		}
+	}
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_48765.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_48765.testjava
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Wilson Ferreira
+ */
+public class LPD_48765 {
+	public AccountEntry method(AccountEntry accountEntry) {
+		if (accountEntry.getType() == CommerceAccountConstants.ACCOUNT_TYPE_PERSONAL) {
+			return accountEntry;
+		}
+	}
+}


### PR DESCRIPTION
Ticket: [LPD-48765](https://liferay.atlassian.net/browse/LPD-48765)

[LPD-48765]: https://liferay.atlassian.net/browse/LPD-48765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ