### PR TITLE
LPD-40240 | SF Automation

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3418,9 +3418,9 @@
 			"ExpandoColumnLocalService",
 			"ExpandoColumnLocalServiceUtil"
 		],
-		"from": "getColumn",
+		"from": "getColumn(long paramName, String paramName)",
 		"issueKey": "LPD-36261",
-		"to": "fetchColumn"
+		"to": "fetchColumn(param#0#, param#1#)"
 	},
 	{
 		"classNames": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_36261.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_36261.testjava
@@ -12,9 +12,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 public class LPD_36261 {
 
-	public void method() {
-		ExpandoColumnLocalServiceUtil.fetchColumn(123, "test123");
-		_expandoColumnLocalService.fetchColumn(123, "test123");
+	public void method(long companyId, String className) {
+		ExpandoColumnLocalServiceUtil.getColumn(123, className);
+		ExpandoColumnLocalServiceUtil.fetchColumn(companyId, className);
+		_expandoColumnLocalService.fetchColumn(companyId, className);
 	}
 
 	@Reference

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_36261.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_36261.testjava
@@ -12,9 +12,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 public class LPD_36261 {
 
-	public void method() {
-		ExpandoColumnLocalServiceUtil.getColumn(123, "test123");
-		_expandoColumnLocalService.getColumn(123, "test123");
+	public void method(long companyId, String className) {
+		ExpandoColumnLocalServiceUtil.getColumn(123, className);
+		ExpandoColumnLocalServiceUtil.getColumn(companyId, className);
+		_expandoColumnLocalService.getColumn(companyId, className);
 	}
 
 	@Reference


### PR DESCRIPTION
ticket: https://liferay.atlassian.net/browse/LPD-40240

Following one of the proposed solutions from the ticket, keep the change/pattern to `fetchColumn` in all cases, and create a new automation pattern in CatchAll change the type to the required parameter when it’s the breaking case.