### PR TITLE
LPD-40685 | SF Automation

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeSetResultsSetTotalMethodCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeSetResultsSetTotalMethodCheck.java
@@ -141,9 +141,7 @@ public class UpgradeSetResultsSetTotalMethodCheck extends BaseUpgradeCheck {
 				content,
 				firstMethodCall + StringPool.SEMICOLON + StringPool.NEW_LINE);
 
-			parameters.add(
-				"() -> " + JavaSourceUtil.getParameters(setResultsMethodCall));
-			parameters.add(JavaSourceUtil.getParameters(setTotalMethodCall));
+			parameters.add(JavaSourceUtil.getParameters(setResultsMethodCall));
 		}
 		else if ((setResultsMethodCall == null) &&
 				 (setTotalMethodCall != null)) {

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJSPFSetResultsSetTotalMethodCheck.testjspf
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJSPFSetResultsSetTotalMethodCheck.testjspf
@@ -8,5 +8,5 @@
 <%
 SearchContainer<Entry> searchContainer = new SearchContainer();
 
-searchContainer.setResultsAndTotal(() -> resultsParameter, totalParameter);
+searchContainer.setResultsAndTotal(resultsParameter);
 %>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJSPSetResultsSetTotalMethodCheck.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJSPSetResultsSetTotalMethodCheck.testjsp
@@ -8,5 +8,5 @@
 <%
 SearchContainer<Entry> searchContainer = new SearchContainer();
 
-searchContainer.setResultsAndTotal(() -> resultsParameter, totalParameter);
+searchContainer.setResultsAndTotal(resultsParameter);
 %>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaSetResultsSetTotalMethodCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaSetResultsSetTotalMethodCheck.testjava
@@ -26,7 +26,7 @@ public class UpgradeJavaSetResultsSetTotalMethodCheck {
 	public SearchContainer<User> setResultsAndTotal(List<User> results, int total) {
 		SearchContainer<Entry> searchContainer = new SearchContainer();
 
-		searchContainer.setResultsAndTotal(() -> results, total);
+		searchContainer.setResultsAndTotal(results);
 
 		return searchContainer;
 	}


### PR DESCRIPTION
ticket: https://liferay.atlassian.net/browse/LPD-40685

To avoid the required `Throwable` exception, we can change how the `setResultsAndTotal` method is used. Instead of receiving the results and total, we can just receive the results list. The total is added in the private method `_setTotal` inside the `SearchContainer` class.

```
	public void setResultsAndTotal(List<R> results) {
		_setTotal(results.size());

		_setResults(results.subList(_start, _resultEnd));
	}
```
