### PR TITLE
LPD-58255 | SF Automation

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeSCSSNodeSassPatternsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeSCSSNodeSassPatternsCheck.java
@@ -8,6 +8,7 @@ package com.liferay.source.formatter.check;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.tools.ToolsUtil;
+import com.liferay.source.formatter.check.util.SourceUtil;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,21 +28,30 @@ public class UpgradeSCSSNodeSassPatternsCheck extends BaseUpgradeCheck {
 
 		boolean replaced = false;
 
+		String line = null;
+
 		while (divisionMatcher.find()) {
-			if (ToolsUtil.isInsideQuotes(content, divisionMatcher.start())) {
+			line = divisionMatcher.group();
+
+			if (ToolsUtil.isInsideQuotes(content, divisionMatcher.start()) ||
+				SourceUtil.containsUnquoted(line, "hsl") ||
+				SourceUtil.containsUnquoted(line, "hsla") ||
+				SourceUtil.containsUnquoted(line, "rgb") ||
+				SourceUtil.containsUnquoted(line, "rgba")) {
+
 				continue;
 			}
 
 			StringBuilder sb = new StringBuilder();
 
 			sb.append("math.div(");
-			sb.append(divisionMatcher.group(1));
-			sb.append(StringPool.COMMA_AND_SPACE);
 			sb.append(divisionMatcher.group(2));
+			sb.append(StringPool.COMMA_AND_SPACE);
+			sb.append(divisionMatcher.group(3));
 			sb.append(StringPool.CLOSE_PARENTHESIS);
 
 			newContent = StringUtil.replace(
-				newContent, divisionMatcher.group(), sb.toString());
+				newContent, divisionMatcher.group(1), sb.toString());
 
 			replaced = true;
 		}
@@ -101,8 +111,10 @@ public class UpgradeSCSSNodeSassPatternsCheck extends BaseUpgradeCheck {
 	}
 
 	private static final Pattern _divisionPattern = Pattern.compile(
-		"(\\w+\\(.+,.+\\)|\\$\\w+|[0-9]+[.]*[0-9]*)\\s*\\/\\s*" +
-			"(\\w+\\(.+,.+\\)|\\$\\w+|[0-9]+[.]*[0-9]*)");
+		"^.*?((\\w+\\([^)]+,[^)]+\\)|\\$[-\\w]+|-?(?:\\d+(?:\\.\\d+)?|" +
+			"\\.\\d+)[a-zA-Z%]*)\\s*/\\s*(\\w+\\([^)]+,[^)]+\\)|\\$[-\\w]+|-?" +
+				"(?:\\d+(?:\\.\\d+)?|\\.\\d+)[a-zA-Z%]*)).*$",
+		Pattern.MULTILINE);
 	private static final Pattern _interpolationPattern = Pattern.compile(
 		"([\\w-\\.]+)\\#\\{([\\w\\.\\$\\(\\), \\&]+)" +
 			"\\}([\\w-\\.\\#\\{\\.\\$\\}]*)");

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeSCSSNodeSassPatternsCheck.testscss
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeSCSSNodeSassPatternsCheck.testscss
@@ -26,3 +26,16 @@ $multiplier: math.div(nth($value, 1), $spacer);
 (#{$prop}: var(#{'--btn-' + $key + '-' + $prefix + $prop}))
 
 (#{$prop}: var(#{'--btn-' + $key + '-' + $prefix + '--btn-'}))
+
+.test-class {
+	color: rgb(0 0 0 / 40%);
+}
+
+.another-element {
+	background-color: rgba(255 0 0 / 0.75);
+}
+
+.my-div {
+	background-color: hsl(0, 100%, 50% / 0.5);
+	color: hsla(240 100% 50% / 0.5);
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeSCSSNodeSassPatternsCheck.testscss
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeSCSSNodeSassPatternsCheck.testscss
@@ -25,3 +25,16 @@ $multiplier: nth($value, 1) / $spacer;
 (#{$prop}: var(--btn-#{$key}-#{$prefix}#{$prop}))
 
 (#{$prop}: var(--btn-#{$key}-#{$prefix}--btn-))
+
+.test-class {
+	color: rgb(0 0 0 / 40%);
+}
+
+.another-element {
+	background-color: rgba(255 0 0 / 0.75);
+}
+
+.my-div {
+	background-color: hsl(0, 100%, 50% / 0.5);
+	color: hsla(240 100% 50% / 0.5);
+}


### PR DESCRIPTION
ticket: https://liferay.atlassian.net/browse/LPD-58255

**How rgb or rgba functions Works**
This syntax provides an alternative to the traditional rgb() and rgba() functions. It's essentially a shorthand that combines the RGB color channels with the alpha (opacity) value.

- `rgb(0 0 0)`: The first three values (0 0 0) represent the red, green, and blue components, respectively.

- `/ 40%`: The slash (/) separates the color values from the alpha or opacity value. This value can be a percentage (like 40%) or a number between 0 and 1 (like 0.4).

Example:
```
.test-class {
  color: rgb(0 0 0 / 40%);
}

.another-element {
  background-color: rgb(255 0 0 / 0.75);
}
```
So after the  `/` the is another number and it is not used as a math.div, it is to keep the same