### PR TITLE
LPD-35263 | Change to use method alterColumnType provided in provided in UpgradeProcess extensions, , instead of instantiating the deprecated AlterColumnType class

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3776,6 +3776,19 @@
 			"UpgradeProcess"
 		],
 		"classStructurePattern": true,
+		"issueKey": "LPD-35263",
+		"methodsToFormat": [
+			{
+				"from": "regex:alter\\(\\s*?(?<tableClass>\\w*),\\s*?new\\s*?AlterColumnType\\(\\s*?(?<columnName>\\w*?)[\\s,]*?(?<newColumnType>\\w*)\\)\\);",
+				"to": "alterColumnType((String)${tableClass}.getField(\\\"TABLE_NAME\\\").get(null), ${columnName}, ${newColumnType});"
+			}
+		]
+	},
+	{
+		"classNames": [
+			"UpgradeProcess"
+		],
+		"classStructurePattern": true,
 		"issueKey": "LPD-35264",
 		"methodsToFormat": [
 			{

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_35263.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_35263.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_35263 extends UpgradeProcess {
+
+	public void method(
+		Class<?> tableClass, String columnName, String newColumnType) {
+
+		alterColumnType((String)tableClass.getField("TABLE_NAME").get(null), columnName, newColumnType);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35263.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35263.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_35263 extends UpgradeProcess {
+
+	public void method(
+		Class<?> tableClass, String columnName, String newColumnType) {
+
+		alter(tableClass, new AlterColumnType(columnName, newColumnType));
+	}
+
+}


### PR DESCRIPTION
Ticket: [LPD-35263](https://liferay.atlassian.net/browse/LPD-35263?atlOrigin=eyJpIjoiMGFiMzA3MWFkNWJlNDVjY2FmZDM2NDUwY2M3NTk2N2MiLCJwIjoiaiJ9)

[LPD-35263]: https://liferay.atlassian.net/browse/LPD-35263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ