### PR TITLE
LPD-58477 Refactor LanguageUtil.formatStorageSize to utilize fileSizeException.getMaxSize() instead of _dlValidator.getMaxAllowableSize()

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5461,6 +5461,25 @@
 		"to": "updateFileEntryAndCheckIn(param#0#, param#1#, param#2#, param#3#, null, param#4#, param#5#, param#6#, param#7#, param#8#, null, null, null, param#9#)"
 	},
 	{
+		"from": "regex:(?<tabs>\\t*)<(?<tag>[\\w\\s%]*(?![%/]>).*)(DLValidatorUtil|_?dlValidator)\\.getMaxAllowableSize\\(null\\)",
+		"issueKey": "LPD-58477",
+		"newImports": [
+			"com.liferay.document.library.kernel.exception.FileSizeException"
+		],
+		"to": "${tabs}<%\n${tabs}FileSizeException fileSizeException = (FileSizeException) errorException;\n${tabs}%>\n\n${tabs}<${tag}fileSizeException.getMaxSize()",
+		"validExtensions": [
+			"jsp"
+		]
+	},
+	{
+		"from": "regex:\\((?<exceptionVar>\\w*) instanceof FileSizeException\\) \\{(?<wrapper>[\\s\\S]*?)(DLValidatorUtil|_?dlValidator)\\.getMaxAllowableSize\\(null\\)",
+		"issueKey": "LPD-58477",
+		"to": "(${exceptionVar} instanceof FileSizeException fileSizeException\\) {${wrapper}fileSizeException.getMaxSize()",
+		"validExtensions": [
+			"java"
+		]
+	},
+	{
 		"classNames": [
 			"PropsKeys"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_58477.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_58477.testjava
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jessyca Ferreira
+ */
+public class LPD_58477 {
+
+	public void method() {
+		if (exception instanceof FileSizeException fileSizeException) {
+			String errorMessage = themeDisplay.translate(
+				"x-message",
+				LanguageUtil.formatStorageSize(
+					fileSizeException.getMaxSize(),
+					themeDisplay.getLocale()));
+		}
+	}
+
+	@Reference
+	private DLValidator _dlValidator;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_58477.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_58477.testjsp
@@ -1,0 +1,14 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ page import="com.liferay.document.library.kernel.exception.FileSizeException" %>
+
+<%
+FileSizeException fileSizeException = (FileSizeException) errorException;
+%>
+
+<liferay-ui:message arguments="<%= LanguageUtil.formatStorageSize(fileSizeException.getMaxSize(), locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58477.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58477.testjava
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jessyca Ferreira
+ */
+public class LPD_58477 {
+
+	public void method() {
+		if (exception instanceof FileSizeException) {
+			String errorMessage = themeDisplay.translate(
+				"x-message",
+				LanguageUtil.formatStorageSize(
+					_dlValidator.getMaxAllowableSize(null),
+					themeDisplay.getLocale()));
+		}
+	}
+
+	@Reference
+	private DLValidator _dlValidator;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58477.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58477.testjsp
@@ -1,0 +1,8 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<liferay-ui:message arguments="<%= LanguageUtil.formatStorageSize(DLValidatorUtil.getMaxAllowableSize(null), locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />


### PR DESCRIPTION
issue: [LPD-58477](https://liferay.atlassian.net/browse/LPD-58477)

All tests passed when running the commands below:

```
gw test --tests com.liferay.source.formatter.processor.UpgradeSourceProcessorTest
gw test --tests UpgradeCatchAllCheckTest
```

[LPD-58477]: https://liferay.atlassian.net/browse/LPD-58477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ