### PR TITLE
LPD-8004 | InfoField.builder method needs to add a .namespace() method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -165,6 +165,19 @@
 		"to": "updateDocument(param#1#, param#2#)"
 	},
 	{
+		"classNames": [
+			"InfoItemFieldReader"
+		],
+		"classStructurePattern": true,
+		"issueKey": "LPD-8004",
+		"methodsToFormat": [
+			{
+				"from": "regex:(?<beforeMethod>implements\\s*?InfoItemFieldReader<(?<classType>\\w+)>\\s*?\\{[\\s\\S]*?@Override\\s*?public\\s*?InfoField\\s*?getInfoField\\(\\)\\s*?\\{[\\s\\S]*?infoFieldType\\(\\s*?\\S*?\\s*?\\))(?!.namespace)",
+				"to": "${beforeMethod}.namespace(\n\t\t\t${classType}.class.getSimpleName()\n\t\t)"
+			}
+		]
+	},
+	{
 		"from": "JSONUtil.isValid",
 		"issueKey": "LPD-8007",
 		"to": "JSONUtil.isJSONObject",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_8004.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_8004.testjava
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.info.item.field.reader.InfoItemFieldReader;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_8004 implements InfoItemFieldReader<t> {
+
+	@Override
+	public InfoField getInfoField() {
+		return InfoField.builder(
+		).infoFieldType(
+			ImageInfoFieldType.INSTANCE
+		).namespace(
+			t.class.getSimpleName()
+		).name(
+			key
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(getClass(), key)
+		).build();
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8004.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8004.testjava
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.info.item.field.reader.InfoItemFieldReader;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_8004 implements InfoItemFieldReader<t> {
+
+	@Override
+	public InfoField getInfoField() {
+		return InfoField.builder(
+		).infoFieldType(
+			ImageInfoFieldType.INSTANCE
+		).name(
+			key
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(getClass(), key)
+		).build();
+	}
+
+}


### PR DESCRIPTION
TIcket: [LPD-8004](https://liferay.atlassian.net/browse/LPD-8004?atlOrigin=eyJpIjoiZTdiYzM3NGU1ZGQ0NDdjYjhkMTI4NWVmOGMzMWI4YzUiLCJwIjoiaiJ9)

[LPD-8004]: https://liferay.atlassian.net/browse/LPD-8004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ