### PR TITLE
LPD-82014 | Automation to alter a incorrect type assignment on Indexer case

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6235,6 +6235,11 @@
 		"to": "Indexer<?>"
 	},
 	{
+		"from": "regex:Indexer<[?\\w\\s]+>\\s+(?<variableName>\\w+)\\s*=\\s*IndexerRegistryUtil\\.nullSafeGetIndexer\\(\\s*(?<className>[\\w.]+)\\.class\\s*\\);",
+		"issueKey": "LPS-191840",
+		"to": "Indexer<${className}> ${variableName} = IndexerRegistryUtil.nullSafeGetIndexer(${className}.class);"
+	},
+	{
 		"classNames": [
 			"Indexer"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPS_191840.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPS_191840.testjava
@@ -11,8 +11,10 @@ package com.liferay.source.formatter.dependencies.upgrade;
 public class LPS_191840 {
 
 	public void method(Indexer<?> indexer) {
-		Map<Indexer<?>, Indexer<?>> indexerRequests = new LinkedHashMap<>();
+		Indexer<BugIndexerPortlet> indexer = IndexerRegistryUtil.nullSafeGetIndexer(BugIndexerPortlet.class);
+
 		List<Indexer<?>> indexers = portlet.getIndexerInstances();
+		Map<Indexer<?>, Indexer<?>> indexerRequests = new LinkedHashMap<>();
 	}
 
 }

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPS_191840.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPS_191840.testjava
@@ -11,8 +11,11 @@ package com.liferay.source.formatter.dependencies.upgrade;
 public class LPS_191840 {
 
 	public void method(Indexer indexer) {
-		Map<Indexer, Indexer> indexerRequests = new LinkedHashMap<>();
+		Indexer indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+			BugIndexerPortlet.class);
+
 		List<Indexer> indexers = portlet.getIndexerInstances();
+		Map<Indexer, Indexer> indexerRequests = new LinkedHashMap<>();
 	}
 
 }


### PR DESCRIPTION
TIcket: [LPD-82014](https://liferay.atlassian.net/browse/LPD-82014?atlOrigin=eyJpIjoiNmE0NmY3MTM5NjZkNDYyNjgxNDJhZmUxMjFkMjIyODIiLCJwIjoiaiJ9)

[LPD-82014]: https://liferay.atlassian.net/browse/LPD-82014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Updating automation with issueKey LPS-191840 to prevent a compilation error caused by  `IndexerRegistryUtil#nullSafeGetIndexer `  where this method returned an generic type. Adjusted the reference to ensure compatibility with the defined type.