### PR TITLE
LPD-84567 | upgradeSourceCode command changes HtmlUtil.stripHtml to HtmlUtil.stripHtmlUtil

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeImportsCheck.java
@@ -155,7 +155,8 @@ public class UpgradeImportsCheck extends BaseFileCheck {
 			String className = entry.getKey();
 
 			String regex = StringBundler.concat(
-				"(?<!\\w-)(\\w*)", className, "(?!\\w)");
+				"((?<![-:</@])\\b_?\\w*(?=", className,
+				"\\b(?!\\s*\\())|\\bget|\\bset)", className, "\\b");
 
 			String newClassName = entry.getValue();
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeImportsCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeImportsCheck.testjava
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
@@ -70,9 +71,10 @@ public class UpgradeImportsCheck extends BaseTableFDSView {
 		return fDSTableSchemaBuilder.build();
 	}
 
-	public method(){
+	public void method() {
 		GroupPermissionUtil.check(null, null, null);
 		GroupPermissionUtil.check(null, null, null);
+		HtmlUtil.stipHtml(null);
 	}
 
 	@Reference

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeImportsCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeImportsCheck.testjava
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
+import com.liferay.portal.kernel.util.Html;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
@@ -68,18 +69,22 @@ public class UpgradeImportsCheck extends BaseTableClayDataSetDisplayView {
 		return clayTableSchemaBuilder.build();
 	}
 
-	public method(){
+	public void method() {
+		_groupPermission.check(null, null, null);
 		_testGroupPermission.check(null, null, null);
-		groupPermission.check(null, null, null);
+		_html.stipHtml(null);
 	}
-
-	@Reference
-	private GroupPermission _testGroupPermission;
 
 	@Reference
 	private ClayTableSchemaBuilderFactory _clayTableSchemaBuilderFactory;
 
 	@Reference
-	private GroupPermission groupPermission;
+	private GroupPermission _groupPermission;
+
+	@Reference
+	private GroupPermission _testGroupPermission;
+
+	@Reference
+	private Html _html;
 
 }


### PR DESCRIPTION
ticket: https://liferay.atlassian.net/browse/LPD-84567

The old regex exhibited undesirable behavior (false positives), such as altering JSP tags, breaking methods with the same name as the variable, and swallowing critical code prefixes, requiring extensive manual correction after the script ran.

- **Variable Path**: Replaces the word, but requires that there be no parentheses immediately following it. This protects methods with the same name from unintended replacements.

- **Get/Set Route**: Replaces the word even if parentheses are present, but requires it to be preceded by get or set (e.g., `getCommerceAccount() ➔ getAccountEntry()`).

- **Front-end Shield ((?<![-:</@]))**: A Negative Lookbehind has been introduced that acts as a shield, immediately aborting the match if the word is inside an XML/JSP tag (e.g.,`<liferay-ddm:html`), preventing front-end breakage.