### PR TITLE
LPD-85990 Replace SitesUtil.setMergeFailCount with LayoutSetPrototypeHelper reference

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5995,6 +5995,15 @@
 		]
 	},
 	{
+		"from": "SitesUtil.setMergeFailCount",
+		"issueKey": "LPD-85990",
+		"newImports": [
+			"com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper"
+		],
+		"newReference": "LayoutSetPrototypeHelper _layoutSetPrototypeHelper",
+		"to": "_layoutSetPrototypeHelper.setMergeFailCount"
+	},
+	{
 		"from": "regex:MultiVMPoolUtil\\s*.\\s*getPortalCache\\(\\s*(?<prefixMethodName>[\\s\\S]*?)\\)",
 		"issueKey": "LPS-153962",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85990.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85990.testjava
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_85990 {
+
+	public void method(
+		LayoutPrototype layoutPrototype, LayoutSetPrototype layoutSetPrototype,
+		int newMergeFailCount) {
+
+		_layoutSetPrototypeHelper.setMergeFailCount(layoutPrototype, newMergeFailCount);
+		_layoutSetPrototypeHelper.setMergeFailCount(layoutSetPrototype, newMergeFailCount);
+	}
+
+	@Reference
+	private LayoutSetPrototypeHelper _layoutSetPrototypeHelper;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85990.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85990.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_85990 {
+
+	public void method(
+		LayoutPrototype layoutPrototype, LayoutSetPrototype layoutSetPrototype,
+		int newMergeFailCount) {
+
+		SitesUtil.setMergeFailCount(layoutPrototype, newMergeFailCount);
+		SitesUtil.setMergeFailCount(layoutSetPrototype, newMergeFailCount);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85990

## Summary

- Adds `replacements.json` pattern to replace `SitesUtil.setMergeFailCount` static calls with an injected `LayoutSetPrototypeHelper` reference
- Both overloads (`LayoutPrototype` and `LayoutSetPrototype`) are handled by the single pattern

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-85990` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)