### PR TITLE
LPD-58184 Warn about removed JournalServiceConfigurationKeys and JournalServiceConfigurationValues

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5111,6 +5111,16 @@
 		]
 	},
 	{
+		"from": "JournalServiceConfigurationKeys",
+		"hasMessage": true,
+		"issueKey": "LPD-58184"
+	},
+	{
+		"from": "JournalServiceConfigurationValues",
+		"hasMessage": true,
+		"issueKey": "LPD-58184"
+	},
+	{
 		"classNames": [
 			"DDMTemplateLocalService",
 			"DDMTemplateLocalServiceUtil"

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58184.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58184.testjava
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.journal.configuration.JournalServiceConfigurationKeys;
+import com.liferay.journal.configuration.JournalServiceConfigurationValues;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_58184 {
+
+	public void method() {
+		String key = JournalServiceConfigurationKeys.CHAR_BLACKLIST;
+		boolean enabled =
+			JournalServiceConfigurationValues.JOURNAL_ARTICLE_COMMENTS_ENABLED;
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58184

## Summary

- Adds `hasMessage` patterns for `JournalServiceConfigurationKeys` and `JournalServiceConfigurationValues`
- Both classes were removed in 2025.Q1.14; the functionality is now available through `JournalServiceConfiguration` injected via `@Reference`
- The pattern fires when either class is found in imports (manual migration required since constants map to methods on the config interface)

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-58184` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)