### PR TITLE
LPD-60817 Warn about CPCompareHelper.getCPDefinitionIds signature change

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5468,6 +5468,7 @@
 	},
 	{
 		"classNames": [
+			"CPCompareHelper",
 			"CPCompareHelperUtil"
 		],
 		"from": "getCPDefinitionIds(long paramName, long paramName, HttpSession paramName)",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61133.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61133.testjava
@@ -5,6 +5,8 @@
 
 package com.liferay.source.formatter.dependencies.upgrade;
 
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Mateus Xavier
  */
@@ -16,6 +18,8 @@ public class LPD_61133 {
 		CPCompareHelperUtil.getCPDefinitionIds(
 			groupId, commerceAccountId, httpSession);
 		CPCompareHelperUtil.getCPDefinitionIds(null, null, null);
+		_cpCompareHelper.getCPDefinitionIds(
+			groupId, commerceAccountId, httpSession);
 	}
 
 	public void method(
@@ -30,5 +34,8 @@ public class LPD_61133 {
 			groupId, commerceAccountId, cpDefinitionId, httpSession);
 		CPCompareHelperUtil.removeCompareProduct(null, null, null, null);
 	}
+
+	@Reference
+	private CPCompareHelper _cpCompareHelper;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-60817

## Summary

- Adds `hasMessage` pattern for `CPCompareHelper.getCPDefinitionIds(long, long, HttpSession)`
- The method signature changed: the third parameter changed from `HttpSession httpSession` to `String cpDefinitionIdsCookieValue`
- Automated replacement is not possible since the cookie value must be extracted from the request manually
- Note: `CPCompareHelperUtil` static variant is already covered by LPD-61133

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-60817` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)