### PR TITLE
LPD-81227 Add getSupportedActions to BasePortletProvider implementations

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5810,6 +5810,19 @@
 	},
 	{
 		"classNames": [
+			"BasePortletProvider"
+		],
+		"classStructurePattern": true,
+		"issueKey": "LPD-81227",
+		"newImports": [
+			"com.liferay.portal.kernel.portlet.PortletProvider"
+		],
+		"newMethods": [
+			"@Override\n\tpublic Action[] getSupportedActions() {\n\t\treturn PortletProvider.Action.values();\n\t}"
+		]
+	},
+	{
+		"classNames": [
 			"AssetEntryLocalService",
 			"AssetEntryLocalServiceUtil"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_81227.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_81227.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.portal.kernel.portlet.PortletProvider;
+
+/**
+ * @author Regisson Aguiar
+ */
+@Component(service = PortletProvider.class)
+public class LPD_81227 extends BasePortletProvider {
+
+	@Override
+	public Action[] getSupportedActions() {
+		return PortletProvider.Action.values();
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_81227.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_81227.testjava
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+@Component(service = PortletProvider.class)
+public class LPD_81227 extends BasePortletProvider {
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-81227

## Summary

- Adds `classStructurePattern` entry to inject `getSupportedActions()` into classes that `extends BasePortletProvider`
- The method was added as abstract to `PortletProvider` (LPS-183518); existing subclasses that pre-date that commit need it added
- Default implementation returns `PortletProvider.Action.values()` to preserve backward-compatible behavior (all actions supported)

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-81227` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)