### PR TITLE
LPD-61487 Warn about FileAttachment constructor parameter change

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5586,6 +5586,11 @@
 		"to": "addUserWithWorkflow(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#, param#12#, param#13#, param#14#, param#15#, param#16#, param#17#, param#18#, UserConstants.TYPE_REGULAR, param#19#, param#20#, param#21#, param#22#, param#23#, param#24#)"
 	},
 	{
+		"from": "new FileAttachment(File paramName, String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-61487"
+	},
+	{
 		"classNames": [
 			"LayoutLocalService",
 			"LayoutLocalServiceUtil",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61487.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61487.testjava
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_61487 {
+
+	public void method(File file, String fileName) {
+		new FileAttachment(file, fileName);
+		new FileAttachment(null, "test123");
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61487

## Summary

- Adds `hasMessage` pattern for the old `FileAttachment(File, String)` constructor
- Constructor was replaced by `FileAttachment(String fileName, InputStream inputStream)` in LPD-52528
- Automated replacement is not possible since converting `File` to `InputStream` requires `IOException` handling that cannot be injected by the formatter

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-61487` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)