### PR TITLE
LPD-47005 Remove Optional from PortletSharedSearchResponse getKeywordsOptional and getSpellCheckSuggestionOptional

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -4503,6 +4503,22 @@
 	},
 	{
 		"classNames": [
+			"PortletSharedSearchResponse"
+		],
+		"from": "getKeywordsOptional",
+		"issueKey": "LPD-47005",
+		"to": "getKeywords"
+	},
+	{
+		"classNames": [
+			"PortletSharedSearchResponse"
+		],
+		"from": "getSpellCheckSuggestionOptional",
+		"issueKey": "LPD-47005",
+		"to": "getSpellCheckSuggestion"
+	},
+	{
+		"classNames": [
 			"SiteNavigationMenuLocalService",
 			"SiteNavigationMenuLocalServiceUtil"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_47005.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_47005.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_47005 {
+
+	public void method() {
+		_portletSharedSearchResponse.getKeywords();
+		_portletSharedSearchResponse.getSpellCheckSuggestion();
+	}
+
+	@Reference
+	private PortletSharedSearchResponse _portletSharedSearchResponse;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_47005.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_47005.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_47005 {
+
+	public void method() {
+		_portletSharedSearchResponse.getKeywordsOptional();
+		_portletSharedSearchResponse.getSpellCheckSuggestionOptional();
+	}
+
+	@Reference
+	private PortletSharedSearchResponse _portletSharedSearchResponse;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-47005

## Summary

- Renames `getKeywordsOptional()` → `getKeywords()` on `PortletSharedSearchResponse`
- Renames `getSpellCheckSuggestionOptional()` → `getSpellCheckSuggestion()` on `PortletSharedSearchResponse`
- `getParameterOptional`/`getPortletPreferencesOptional` renames are already covered by LPD-31994

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-47005` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)