### PR TITLE
LPD-58414 Rename getContent to renderPreview in BaseCTDisplayRenderer subclasses

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5204,6 +5204,22 @@
 	},
 	{
 		"classNames": [
+			"BaseCTDisplayRenderer"
+		],
+		"classStructurePattern": true,
+		"issueKey": "LPD-58414",
+		"methodsToFormat": [
+			{
+				"from": "regex:@Override\\n\\tpublic String getContent\\(\\n\\t\\t\\t\\w+ \\w+,\\n\\t\\t\\t\\w+ \\w+, Locale \\w+, (?<genericType>\\w+) \\w+\\)\\n\\t\\tthrows Exception",
+				"to": "@Override\n\tpublic String renderPreview(DisplayContext<${genericType}> displayContext)\n\t\tthrows Exception"
+			}
+		],
+		"newImports": [
+			"com.liferay.change.tracking.spi.display.context.DisplayContext"
+		]
+	},
+	{
+		"classNames": [
 			"LayoutCopyHelper"
 		],
 		"from": "copyLayout",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_58414.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_58414.testjava
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.change.tracking.spi.display.context.DisplayContext;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_58414 extends BaseCTDisplayRenderer {
+
+	@Override
+	public String renderPreview(DisplayContext<T> displayContext)
+		throws Exception {
+
+		return model.toString();
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58414.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58414.testjava
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_58414 extends BaseCTDisplayRenderer {
+
+	@Override
+	public String getContent(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale locale, T model)
+		throws Exception {
+
+		return model.toString();
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58414

## Summary

- Adds `classStructurePattern` + `methodsToFormat` (regex) to replace the deprecated `getContent(HttpServletRequest, HttpServletResponse, Locale, T)` method signature with `renderPreview(DisplayContext<T>)` in classes that extend `BaseCTDisplayRenderer`
- The deprecated method was removed in LPS-197849
- The method signature is renamed; the body is preserved as-is — developers must manually update the body to use `displayContext` accessors

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-58414` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)