### PR TITLE
LPD-8019 Warn about removed InfoItemReference.getClassPK method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -216,6 +216,17 @@
 	},
 	{
 		"classNames": [
+			"InfoItemReference"
+		],
+		"from": "regex:(?<infoItemReference>\\w+)\\.getClassPK\\(\\)",
+		"issueKey": "LPD-8019",
+		"newImports": [
+			"com.liferay.info.item.ClassPKInfoItemIdentifier"
+		],
+		"to": "((ClassPKInfoItemIdentifier)${infoItemReference}.getInfoItemIdentifier()).getClassPK()"
+	},
+	{
+		"classNames": [
 			"HttpServletRequest"
 		],
 		"from": "regex:\t*(?s)\\b\\w+\\s*\\.setAttribute\\s*\\(\\s*InfoDisplayWebKeys\\s*\\.INFO_ITEM_FIELD_VALUES_PROVIDER\\s*,.*?\\);\n",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_8019.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_8019.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_8019 {
+
+	public void method(InfoItemReference infoItemReference) {
+		((ClassPKInfoItemIdentifier)infoItemReference.getInfoItemIdentifier()).getClassPK();
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8019.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8019.testjava
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_8019 {
+
+	public void method(InfoItemReference infoItemReference) {
+		infoItemReference.getClassPK();
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-8019

## Summary

- Adds `hasMessage` for `InfoItemReference.getClassPK()` which was removed
- Callers must now use `((ClassPKInfoItemIdentifier)infoItemReference.getInfoItemIdentifier()).getClassPK()`

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-8019` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)