### PR TITLE
LPD-8037 Warn about removed ContentUtil.get replaced by StringUtil.read

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -243,6 +243,15 @@
 		"to": ""
 	},
 	{
+		"from": "ContentUtil.get(ClassLoader paramName, String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-8037",
+		"validExtensions": [
+			"java",
+			"jsp"
+		]
+	},
+	{
 		"classNames": [
 			"LayoutItemSelectorCriterion"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8037.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8037.testjava
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_8037 {
+
+	public void method(ClassLoader classLoader, String location) {
+		ContentUtil.get(classLoader, location);
+		ContentUtil.get(null, null);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8037.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8037.testjsp
@@ -1,0 +1,10 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+String content = ContentUtil.get(classLoader, location);
+%>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-8037

## Summary

- Adds `hasMessage` for `ContentUtil.get(ClassLoader, String)` in Java files
- Adds `hasMessage` for `ContentUtil.get` in JSP files
- `ContentUtil` was removed (LPS-149147); the replacement `StringUtil.read` throws `IOException` requiring manual migration to add proper exception handling

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-8037` passes (Java + JSP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)