### PR TITLE
LPD-34692 Warn about removed MessageBus.registerMessageListener and unregisterMessageListener

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3541,6 +3541,22 @@
 	},
 	{
 		"classNames": [
+			"MessageBus"
+		],
+		"from": "registerMessageListener(String paramName, MessageListener paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-34692"
+	},
+	{
+		"classNames": [
+			"MessageBus"
+		],
+		"from": "unregisterMessageListener(String paramName, MessageListener paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-34692"
+	},
+	{
+		"classNames": [
 			"MentionsUserFinder"
 		],
 		"classStructurePattern": true,

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_34692.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_34692.testjava
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_34692 {
+
+	public void method(
+		String destinationName, MessageListener messageListener) {
+
+		_messageBus.registerMessageListener(destinationName, messageListener);
+		_messageBus.registerMessageListener(null, null);
+
+		_messageBus.unregisterMessageListener(destinationName, messageListener);
+		_messageBus.unregisterMessageListener(null, null);
+	}
+
+	@Reference
+	private MessageBus _messageBus;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34692

## Summary

- Adds `hasMessage` for `MessageBus.registerMessageListener(String, MessageListener)`
- Adds `hasMessage` for `MessageBus.unregisterMessageListener(String, MessageListener)`
- These methods were removed (LPS-171291); Liferay now auto-activates `MessageListener` implementations via OSGi, so explicit Registration classes should be deleted

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-34692` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)