### PR TITLE
LPD-35240 Warn about removed SoyDataFactory.createSoyHTMLData and createSoyRawData

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3667,6 +3667,22 @@
 	},
 	{
 		"classNames": [
+			"SoyDataFactory"
+		],
+		"from": "createSoyHTMLData(String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-35240"
+	},
+	{
+		"classNames": [
+			"SoyDataFactory"
+		],
+		"from": "createSoyRawData(String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-35240"
+	},
+	{
+		"classNames": [
 			"UpgradeProcess"
 		],
 		"classStructurePattern": true,

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35240.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35240.testjava
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_35240 {
+
+	public void method(String html) {
+		_soyDataFactory.createSoyHTMLData(html);
+		_soyDataFactory.createSoyHTMLData(null);
+
+		_soyDataFactory.createSoyRawData(html);
+		_soyDataFactory.createSoyRawData(null);
+	}
+
+	@Reference
+	private SoyDataFactory _soyDataFactory;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-35240

## Summary

- Adds `hasMessage` for `SoyDataFactory.createSoyHTMLData(String)` and `createSoyRawData(String)`
- The `portal-template-soy` module was removed in LPS-122956; string conversion to `SoyRawData`/`SoyHTMLData` is no longer necessary
- Callers must manually remove the `SoyDataFactory` wrapper and pass the `String` directly to wherever the wrapped value was used

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-35240` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)