### PR TITLE
LPD-31312 Warn about removed RecurrenceSerializer.toCronText method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3502,6 +3502,14 @@
 	},
 	{
 		"classNames": [
+			"RecurrenceSerializer"
+		],
+		"from": "toCronText(Recurrence paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-31312"
+	},
+	{
+		"classNames": [
 			"CustomFacetPortletPreferences"
 		],
 		"from": "getFederatedSearchKeyOptional",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31312.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31312.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.calendar.recurrence.Recurrence;
+import com.liferay.calendar.recurrence.RecurrenceSerializer;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_31312 {
+
+	public void method(Recurrence recurrence) {
+		RecurrenceSerializer.toCronText(null);
+		RecurrenceSerializer.toCronText(recurrence);
+	}
+
+}


### PR DESCRIPTION
ticket: https://liferay.atlassian.net/browse/LPD-31312
## Summary

- Adds `hasMessage` entry for `RecurrenceSerializer.toCronText` which was removed
- Warns developers to manually migrate to `CronTextUtil.getCronText` (signatures differ — automated replacement is not safe)

## Test plan

- [ ] `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-31312`

🤖 Generated with [Claude Code](https://claude.com/claude-code)