### PR TITLE
LPD-61351 Fix UpgradeJavaGetFileMethodCheck to wrap getFileAsStream inline

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaGetFileMethodCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaGetFileMethodCheck.java
@@ -6,7 +6,6 @@
 package com.liferay.source.formatter.check;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.check.util.JavaSourceUtil;
 
@@ -54,9 +53,9 @@ public class UpgradeJavaGetFileMethodCheck extends BaseFileCheck {
 
 				content = _formatMethodCall(
 					content, methodCall, matcher.group(1));
-			}
 
-			replaced = true;
+				replaced = true;
+			}
 		}
 
 		if (replaced) {
@@ -77,28 +76,13 @@ public class UpgradeJavaGetFileMethodCheck extends BaseFileCheck {
 			return content;
 		}
 
+		String newMethodCall = StringBundler.concat(
+			variableName, "FileUtil.createTempFile(",
+			getVariableName(methodCall), ".getFileAsStream(",
+			StringUtil.merge(parameterNames, ", "), "))");
+
 		return StringUtil.replace(
-			content, variableName + methodCall,
-			_getNewMethodCall(methodCall, parameterNames, variableName));
-	}
-
-	private String _getNewMethodCall(
-		String methodCall, List<String> parameterNames, String variableName) {
-
-		StringBundler sb = new StringBundler(10);
-
-		sb.append("\t\tInputStream inputStream = ");
-		sb.append(getVariableName(methodCall));
-		sb.append(".getFileAsStream(");
-		sb.append(StringUtil.merge(parameterNames, ", "));
-		sb.append(StringPool.CLOSE_PARENTHESIS);
-		sb.append(StringPool.SEMICOLON);
-		sb.append(StringPool.NEW_LINE);
-		sb.append(StringPool.NEW_LINE);
-		sb.append(variableName);
-		sb.append("FileUtil.createTempFile(inputStream)");
-
-		return sb.toString();
+			content, variableName + methodCall, newMethodCall);
 	}
 
 	private static final Pattern _getFilePattern = Pattern.compile(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaGetFileMethodCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaGetFileMethodCheck.testjava
@@ -19,15 +19,11 @@ public class UpgradeJavaGetFileMethodCheck {
 
 		// Test local service class method
 
-		InputStream inputStream = _dlFileEntryLocalService.getFileAsStream(fileEntryId, fileEntryVersion, true);
-
-		File file = FileUtil.createTempFile(inputStream);
+		File file = FileUtil.createTempFile(_dlFileEntryLocalService.getFileAsStream(fileEntryId, fileEntryVersion, true));
 
 		// Test utility class method
 
-		InputStream inputStream = DLFileEntryLocalServiceUtil.getFileAsStream(fileEntryId, fileEntryVersion, true);
-
-		return FileUtil.createTempFile(inputStream);
+		return FileUtil.createTempFile(DLFileEntryLocalServiceUtil.getFileAsStream(fileEntryId, fileEntryVersion, true));
 	}
 
 	@Reference


### PR DESCRIPTION
## Summary

- The old implementation introduced a new `InputStream inputStream` variable per call, causing:
  1. **Duplicate variable declarations** when a method had more than one `getFile` call (compile error)
  2. **Missing `import java.io.InputStream`**
  3. **Wrong import ordering** — `FileUtil` was prepended before existing imports
  4. **Hardcoded `\t\t` indentation** regardless of actual call-site depth
- Fix: replace `receiver.getFile(p0, p1, p2)` inline as `FileUtil.createTempFile(receiver.getFileAsStream(p0, p1, p2))`, keeping the existing prefix (variable declaration or `return`) unchanged
- Also fixed: `replaced = true` was set even when the class check failed, causing spurious `FileUtil` imports

## Test plan

- [ ] `gw test --tests "com.liferay.source.formatter.processor.UpgradeSourceProcessorTest.testUpgradeJavaGetFileMethodCheck"`
- [ ] `gw test --tests "com.liferay.source.formatter.processor.UpgradeSourceProcessorTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)