### PR TITLE
LPD-61485 Replace FileAttachment.getFile with getInputStream

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5587,6 +5587,17 @@
 	},
 	{
 		"classNames": [
+			"FileAttachment"
+		],
+		"from": "getFile()",
+		"hasMessage": true,
+		"issueKey": "LPD-61485",
+		"validExtensions": [
+			"java"
+		]
+	},
+	{
+		"classNames": [
 			"LayoutLocalService",
 			"LayoutLocalServiceUtil",
 			"LayoutService",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61485.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61485.testjava
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.mail.kernel.model.FileAttachment;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_61485 {
+
+	public void method(FileAttachment fileAttachment) {
+		_fileAttachment.getFile();
+		fileAttachment.getFile();
+	}
+
+	private FileAttachment _fileAttachment;
+
+}


### PR DESCRIPTION
## Summary
- Adds `UpgradeCatchAllCheck` replacement for `FileAttachment.getFile()` → `FileAttachment.getInputStream()`
- The `getFile()` method was removed from `FileAttachment`; `getInputStream()` is its replacement

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-61485`