### PR TITLE
LPD-60899 Replace PortletSharedSearchSettings.getParameterValues71 with getParameterValues

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5460,6 +5460,14 @@
 	},
 	{
 		"classNames": [
+			"PortletSharedSearchSettings"
+		],
+		"from": "getParameterValues71",
+		"issueKey": "LPD-60899",
+		"to": "getParameterValues"
+	},
+	{
+		"classNames": [
 			"CPCompareHelperUtil"
 		],
 		"from": "addCompareProduct(long paramName, long paramName, long paramName, HttpSession paramName)",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_60899.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_60899.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_60899 {
+
+	public void method(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		portletSharedSearchSettings.getParameterValues("key");
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_60899.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_60899.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_60899 {
+
+	public void method(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		portletSharedSearchSettings.getParameterValues71("key");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `UpgradeCatchAllCheck` replacement for `PortletSharedSearchSettings.getParameterValues71()` → `getParameterValues()`
- The `getParameterValues71` method was renamed to `getParameterValues`

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-60899`

ticket: https://liferay.atlassian.net/browse/LPD-60899