### PR TITLE
LPD-28870 Warn about removed getDDMFormValues in DDMFormViewFormInstanceRecordsDisplayContext

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3137,6 +3137,14 @@
 		"to": "addCompany(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, true, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#)"
 	},
 	{
+		"classNames": [
+			"DDMFormViewFormInstanceRecordsDisplayContext"
+		],
+		"from": "getDDMFormValues(DDMFormInstanceRecord paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-28870"
+	},
+	{
 		"from": "new CommerceCatalogCreateDateComparator()",
 		"issueKey": "LPD-29234",
 		"skipParametersValidation": true,

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_28870.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_28870.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_28870 {
+
+	public void method(
+		DDMFormViewFormInstanceRecordsDisplayContext
+			ddmFormViewFormInstanceRecordsDisplayContext,
+		DDMFormInstanceRecord ddmFormInstanceRecord) {
+
+		ddmFormViewFormInstanceRecordsDisplayContext.getDDMFormValues(
+			ddmFormInstanceRecord);
+		ddmFormViewFormInstanceRecordsDisplayContext.getDDMFormValues(null);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `hasMessage` warning for `DDMFormViewFormInstanceRecordsDisplayContext.getDDMFormValues()` which was replaced by `getDDMForm()` and `getDDMFormFieldValues()`
- The full transformation (removing variable and replacing usages) requires manual intervention

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-28870`