### PR TITLE
LPD-30556 Warn about changed serialize/deserialize API in DDMFormJSON classes

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3459,6 +3459,22 @@
 	},
 	{
 		"classNames": [
+			"DDMFormJSONDeserializer"
+		],
+		"from": "deserialize(String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-30556"
+	},
+	{
+		"classNames": [
+			"DDMFormJSONSerializer"
+		],
+		"from": "serialize(DDMForm paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-30556"
+	},
+	{
+		"classNames": [
 			"JournalArticle"
 		],
 		"from": "setDDMStructureKey(String paramName)",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_30556.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_30556.testjava
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_30556 {
+
+	public void method(DDMForm ddmForm, String definition) {
+		_ddmFormJSONDeserializer.deserialize(definition);
+		_ddmFormJSONDeserializer.deserialize(null);
+
+		_ddmFormJSONSerializer.serialize(ddmForm);
+		_ddmFormJSONSerializer.serialize(null);
+	}
+
+	@Reference
+	private DDMFormJSONDeserializer _ddmFormJSONDeserializer;
+
+	@Reference
+	private DDMFormJSONSerializer _ddmFormJSONSerializer;
+
+}


### PR DESCRIPTION
## Summary
- Adds `hasMessage` warnings for the old `DDMFormJSONDeserializer.deserialize(String)` and `DDMFormJSONSerializer.serialize(DDMForm)` method signatures
- The API changed to use builder-pattern request/response objects (`DDMFormDeserializerDeserializeRequest`, `DDMFormSerializerSerializeRequest`)

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-30556`