### PR TITLE
LPD-27965 Remove SafeConsumer.ignore wrapping of dropdown item lambdas

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -2575,6 +2575,11 @@
 		]
 	},
 	{
+		"from": "regex:SafeConsumer\\.ignore\\(\\s*(?<lambda>dropdownItem\\s*->\\s*\\{[\\s\\S]*?}\\s*)\\)",
+		"issueKey": "LPD-27965",
+		"to": "${lambda}"
+	},
+	{
 		"classNames": [
 			"BaseJSPDynamicInclude"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_27965.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_27965.testjava
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_27965 {
+
+	public void method() {
+		add(
+			dropdownItem -> {
+					dropdownItem.setActive(true);
+				});
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_27965.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_27965.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_27965 {
+
+	public void method() {
+		add(
+			SafeConsumer.ignore(
+				dropdownItem -> {
+					dropdownItem.setActive(true);
+				}));
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `UpgradeCatchAllCheck` regex replacement to remove `SafeConsumer.ignore()` wrapping from dropdown item lambdas
- The `SafeConsumer.ignore()` wrapper is no longer needed; the lambda can be used directly

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-27965`