### PR TITLE
LPD-28363 Remove redundant company send password check

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3076,6 +3076,16 @@
 		]
 	},
 	{
+		"from": "regex:!company\\.isSendPassword\\(\\) && (?<condition>!company\\.isSendPasswordResetLink\\(\\))",
+		"issueKey": "LPD-28363",
+		"to": "${condition}"
+	},
+	{
+		"from": "regex:PropsKeys\\.COMPANY_SECURITY_SEND_PASSWORD,\\s+(?<suffix>PropsKeys\\.COMPANY_SECURITY_SEND_PASSWORD_RESET_LINK)",
+		"issueKey": "LPD-28363",
+		"to": "${suffix}"
+	},
+	{
 		"classNames": [
 			"StrutsAction"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_28363.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_28363.testjava
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_28363 {
+
+	public void method(Company company) {
+		if (!company.isSendPasswordResetLink()) {
+			doSomething();
+		}
+
+		addProps(
+			PropsKeys.COMPANY_SECURITY_SEND_PASSWORD_RESET_LINK);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_28363.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_28363.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_28363 {
+
+	public void method(Company company) {
+		if (!company.isSendPassword() && !company.isSendPasswordResetLink()) {
+			doSomething();
+		}
+
+		addProps(
+			PropsKeys.COMPANY_SECURITY_SEND_PASSWORD,
+			PropsKeys.COMPANY_SECURITY_SEND_PASSWORD_RESET_LINK);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds two `UpgradeCatchAllCheck` regex replacements for company send-password condition simplification
- The `!company.isSendPassword() &&` prefix is now redundant; only the `!company.isSendPasswordResetLink()` condition needs to remain
- The `PropsKeys.COMPANY_SECURITY_SEND_PASSWORD,` entry is also removed from addProps calls

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-28363`