### PR TITLE
LPD-58480 Warn about removed HttpComponentsUtil.getParameterMap method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5425,6 +5425,14 @@
 	},
 	{
 		"classNames": [
+			"HttpComponentsUtil"
+		],
+		"from": "getParameterMap()",
+		"hasMessage": true,
+		"issueKey": "LPD-58480"
+	},
+	{
+		"classNames": [
 			"PropsKeys"
 		],
 		"from": "COMPANY_SECURITY_AUTH_REQUIRES_HTTPS",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58480.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58480.testjava
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_58480 {
+
+	public void method() {
+		HttpComponentsUtil.getParameterMap();
+		HttpComponentsUtil.getParameterMap();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `hasMessage` entry for `HttpComponentsUtil.getParameterMap()` which was removed
- Warns developers to manually migrate to the replacement (no safe automated replacement exists)

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-58480`