### PR TITLE
LPD-61579 Update ParamAndPropertyAncestorTagImpl to use accessor methods

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5531,6 +5531,27 @@
 	},
 	{
 		"classNames": [
+			"ParamAndPropertyAncestorTagImpl"
+		],
+		"classStructurePattern": true,
+		"issueKey": "LPD-61579",
+		"methodsToFormat": [
+			{
+				"from": "regex:FileAvailabilityUtil\\.isAvailable\\(servletContext, (?<page>[^)]+)\\)",
+				"to": "FileAvailabilityUtil.isAvailable(getServletContext(), ${page})"
+			},
+			{
+				"from": "servletContext = ServletContextUtil.getServletContext()",
+				"to": "setServletContext(ServletContextUtil.getServletContext())"
+			},
+			{
+				"from": "setAttributes(request)",
+				"to": "setAttributes(getRequest())"
+			}
+		]
+	},
+	{
+		"classNames": [
 			"JournalArticleLocalService",
 			"JournalArticleLocalServiceUtil",
 			"JournalArticleService",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_61579.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_61579.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_61579 extends ParamAndPropertyAncestorTagImpl {
+
+	public void method() {
+		setServletContext(ServletContextUtil.getServletContext());
+
+		if (FileAvailabilityUtil.isAvailable(getServletContext(), "page")) {
+			setAttributes(getRequest());
+		}
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61579.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61579.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_61579 extends ParamAndPropertyAncestorTagImpl {
+
+	public void method() {
+		servletContext = ServletContextUtil.getServletContext();
+
+		if (FileAvailabilityUtil.isAvailable(servletContext, "page")) {
+			setAttributes(request);
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `classStructurePattern` entry for classes extending `ParamAndPropertyAncestorTagImpl`
- Replaces direct field access and bare calls with proper accessor methods: `servletContext` → `getServletContext()`, `request` → `getRequest()`
- Specifically handles `FileAvailabilityUtil.isAvailable`, `ServletContextUtil.getServletContext`, and `setAttributes` call sites

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-61579`