### PR TITLE
LPD-70233 Replace Language.get(PageContext) with request-based equivalent

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5750,6 +5750,27 @@
 	},
 	{
 		"classNames": [
+			"Language",
+			"LanguageUtil"
+		],
+		"from": "get(PageContext paramName, String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-70233",
+		"validExtensions": [
+			"java"
+		]
+	},
+	{
+		"from": "regex:(?<class>Language(?:Util)?)\\.(?<method>format|get)\\(pageContext,",
+		"issueKey": "LPD-70233",
+		"to": "${class}.${method}(request,",
+		"validExtensions": [
+			"jsp",
+			"jspf"
+		]
+	},
+	{
+		"classNames": [
 			"FFDocumentLibraryDDMEditorConfigurationUtil"
 		],
 		"from": "useDataEngineEditor()",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_70233.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_70233.testjsp
@@ -1,0 +1,13 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+Language.format(request, "key", (Object[])null);
+Language.get(request, "key");
+LanguageUtil.format(request, "key", (Object[])null);
+LanguageUtil.get(request, "key");
+%>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_70233.testjspf
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_70233.testjspf
@@ -1,0 +1,13 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+Language.format(request, "key", (Object[])null);
+Language.get(request, "key");
+LanguageUtil.format(request, "key", (Object[])null);
+LanguageUtil.get(request, "key");
+%>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjava
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_70233 {
+
+	public void method(PageContext pageContext, String key) {
+		LanguageUtil.get(null, key);
+		LanguageUtil.get(pageContext, key);
+		_language.get(pageContext, key);
+	}
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjsp
@@ -1,0 +1,13 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+Language.format(pageContext, "key", (Object[])null);
+Language.get(pageContext, "key");
+LanguageUtil.format(pageContext, "key", (Object[])null);
+LanguageUtil.get(pageContext, "key");
+%>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjspf
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjspf
@@ -1,0 +1,13 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+Language.format(pageContext, "key", (Object[])null);
+Language.get(pageContext, "key");
+LanguageUtil.format(pageContext, "key", (Object[])null);
+LanguageUtil.get(pageContext, "key");
+%>


### PR DESCRIPTION
## Summary
- Adds `hasMessage` warning for `Language.get(PageContext, String)` and `LanguageUtil.get(PageContext, String)` in Java — `PageContext` overloads were removed; manual migration to the `HttpServletRequest` variant is required
- Adds `UpgradeCatchAllCheck` regex replacement for JSP/JSPF files: replaces `Language.get(pageContext,` and `Language.format(pageContext,` (and `LanguageUtil` variants) with the equivalent `request`-based calls

## Test plan
- [ ] Run `gw test --tests UpgradeCatchAllCheckTest -Dissue.key=LPD-70233`