### PR TITLE
LPD-62937 Fix parser crash on trailing comment after closing brace

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeCatchAllCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeCatchAllCheck.java
@@ -24,6 +24,7 @@ import com.liferay.source.formatter.parser.JavaClassParser;
 import com.liferay.source.formatter.parser.JavaMethod;
 import com.liferay.source.formatter.parser.JavaTerm;
 import com.liferay.source.formatter.parser.JavaVariable;
+import com.liferay.source.formatter.parser.ParseException;
 
 import java.io.File;
 
@@ -648,7 +649,14 @@ public class UpgradeCatchAllCheck extends BaseFileCheck {
 
 		String newContent = content;
 
-		JavaClass javaClass = JavaClassParser.parseJavaClass(fileName, content);
+		JavaClass javaClass;
+
+		try {
+			javaClass = JavaClassParser.parseJavaClass(fileName, content);
+		}
+		catch (ParseException parseException) {
+			return newContent;
+		}
 
 		if (!jsonObject.getBoolean("classStructurePattern") &&
 			!jsonObject.has("removeImplements")) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeImportsCheck.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.JSPImportsFormatter;
 import com.liferay.source.formatter.parser.JavaClass;
 import com.liferay.source.formatter.parser.JavaClassParser;
+import com.liferay.source.formatter.parser.ParseException;
 import com.liferay.source.formatter.util.SourceFormatterUtil;
 
 import java.io.InputStream;
@@ -79,10 +80,15 @@ public class UpgradeImportsCheck extends BaseFileCheck {
 		List<String> importNames = new ArrayList<>();
 
 		if (fileName.endsWith(".java")) {
-			JavaClass javaClass = JavaClassParser.parseJavaClass(
-				fileName, content);
+			try {
+				JavaClass javaClass = JavaClassParser.parseJavaClass(
+					fileName, content);
 
-			importNames = javaClass.getImportNames();
+				importNames = javaClass.getImportNames();
+			}
+			catch (ParseException parseException) {
+				return importNames;
+			}
 		}
 		else if (fileName.endsWith(".jsp")) {
 			importNames = JSPImportsFormatter.getImportNames(content);
@@ -146,9 +152,14 @@ public class UpgradeImportsCheck extends BaseFileCheck {
 		String newContent = content;
 
 		if (fileName.endsWith(".java")) {
-			javaClass = JavaClassParser.parseJavaClass(fileName, content);
+			try {
+				javaClass = JavaClassParser.parseJavaClass(fileName, content);
 
-			newContent = javaClass.getContent();
+				newContent = javaClass.getContent();
+			}
+			catch (ParseException parseException) {
+				return content;
+			}
 		}
 
 		for (Map.Entry<String, String> entry : variablesMap.entrySet()) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -284,6 +284,17 @@ public class JavaClassParser {
 			if (lastChildDetailAST.getType() == TokenTypes.SLIST) {
 				lastChildDetailAST = lastChildDetailAST.getLastChild();
 
+				if (lastChildDetailAST == null) {
+					return null;
+				}
+
+				if (lastChildDetailAST.getType() ==
+						TokenTypes.SINGLE_LINE_COMMENT) {
+
+					lastChildDetailAST =
+						lastChildDetailAST.getPreviousSibling();
+				}
+
 				if ((lastChildDetailAST == null) ||
 					(lastChildDetailAST.getType() != TokenTypes.RCURLY)) {
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeImportsCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeImportsCheck.testjava
@@ -75,6 +75,10 @@ public class UpgradeImportsCheck extends BaseTableFDSView {
 		GroupPermissionUtil.check(null, null, null);
 	}
 
+	public void methodWithTrailingComment() {
+		PortalUtil.getPortalURL(null, null, false);
+	} // trailing comment
+
 	@Reference
 	private FDSTableSchemaBuilderFactory _fDSTableSchemaBuilderFactory;
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeImportsCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeImportsCheck.testjava
@@ -73,6 +73,10 @@ public class UpgradeImportsCheck extends BaseTableClayDataSetDisplayView {
 		groupPermission.check(null, null, null);
 	}
 
+	public void methodWithTrailingComment() {
+		PortalUtil.getPortalURL(null, null, false);
+	} // trailing comment
+
 	@Reference
 	private GroupPermission _testGroupPermission;
 


### PR DESCRIPTION
## Summary

- Fix `JavaClassParser._getEndPosition` for METHOD_DEF/CTOR_DEF: add the same `SINGLE_LINE_COMMENT` skip that already exists for CLASS_DEF, so Checkstyle's `WITH_COMMENTS` mode appending a comment token after `RCURLY` inside SLIST no longer causes a null return and `ParseException`
- Catch `ParseException` gracefully in `UpgradeCatchAllCheck._formatJava` and `UpgradeImportsCheck._getImportNames`/`_replaceVariables` so files that still cannot be parsed are skipped instead of crashing the upgrade formatter
- Add a trailing-comment method to `UpgradeImportsCheck.testjava` to cover the fixed code path

## Test plan

- [ ] Run `gw test --tests com.liferay.source.formatter.processor.UpgradeSourceProcessorTest.testUpgradeImportsCheck`
- [ ] Run `ci:test:sf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)