### PR TITLE
LPD-31312 Warn about removed RecurrenceSerializer.toCronText method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3502,6 +3502,14 @@
 	},
 	{
 		"classNames": [
+			"RecurrenceSerializer"
+		],
+		"from": "toCronText(Recurrence paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-31312"
+	},
+	{
+		"classNames": [
 			"CustomFacetPortletPreferences"
 		],
 		"from": "getFederatedSearchKeyOptional",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31312.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31312.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.calendar.recurrence.Recurrence;
+import com.liferay.calendar.recurrence.RecurrenceSerializer;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_31312 {
+
+	public void method(Recurrence recurrence) {
+		RecurrenceSerializer.toCronText(recurrence);
+		RecurrenceSerializer.toCronText(null);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-31312

## What Is Being Fixed

`RecurrenceSerializer.toCronText(Recurrence)` was removed from the Liferay
platform. Any code that calls this method will break after upgrading.

## How It Is Being Fixed

A `hasMessage: true` entry is added to `replacements.json` so Source Formatter
emits a warning on every call site of `RecurrenceSerializer.toCronText(Recurrence)`,
telling the developer the method was removed and their code must be updated.

A test file (`LPD_31312.testjava`) is added to verify the warning fires for
both a typed argument and a `null` argument (Rule 202: `null` last).

## PR Check

**pr-check: PASS** — tested on `cbe3606abbed262fd559e0e2ac3a4e40ebf101a3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "cbe3606abbed262fd559e0e2ac3a4e40ebf101a3"} -->