### PR TITLE
LPD-28870 DDMFormViewFormInstanceRecordsDisplayContext's getDDMFormValues method was replaced

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3137,6 +3137,11 @@
 		"to": "addCompany(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, true, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#)"
 	},
 	{
+		"from": "regex:_?\\w*FormInstanceRecordsDisplayContext\\.getDDMFormValues\\(\\s*(?<variableName>\\w*?[iI]nstanceRecord)\\s*\\)",
+		"issueKey": "LPD-28870",
+		"to": "${variableName}.getFormInstanceRecordVersion().getDDMFormValues()"
+	},
+	{
 		"from": "new CommerceCatalogCreateDateComparator()",
 		"issueKey": "LPD-29234",
 		"skipParametersValidation": true,

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_28870.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_28870.testjava
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.dynamic.data.mapping.form.web.internal.display.context.DDMFormViewFormInstanceRecordsDisplayContext;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+
+/**
+ * @author Jessyca Ferreira
+ */
+public class LPD_28870 {
+
+	public void method(
+		DDMFormViewFormInstanceRecordsDisplayContext
+			ddmFormViewFormInstanceRecordsDisplayContext,
+		DDMFormInstanceRecord formInstanceRecord) {
+
+		DDMFormValues ddmFormValues =
+			formInstanceRecord.getFormInstanceRecordVersion().getDDMFormValues();
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_28870.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_28870.testjava
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.dynamic.data.mapping.form.web.internal.display.context.DDMFormViewFormInstanceRecordsDisplayContext;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+
+/**
+ * @author Jessyca Ferreira
+ */
+public class LPD_28870 {
+
+	public void method(
+		DDMFormViewFormInstanceRecordsDisplayContext
+			ddmFormViewFormInstanceRecordsDisplayContext,
+		DDMFormInstanceRecord formInstanceRecord) {
+
+		DDMFormValues ddmFormValues =
+			ddmFormViewFormInstanceRecordsDisplayContext.getDDMFormValues(
+				formInstanceRecord);
+	}
+
+}


### PR DESCRIPTION
issue: [LPD-28870](https://liferay.atlassian.net/browse/LPD-28870)

Calling `ddmFormViewFormInstanceRecordsDisplayContext.getDDMFormValues() `is no longer supported, so its result can no longer be directly assigned to `ddmFormValues`. The ticket suggests replacing individual method calls of ddmFormValues with alternatives from `ddmFormViewFormInstanceRecordsDisplayContext`. However, fully removing ddmFormValues risks breaking code that relies on the instance, because not every method present in ddmFormValues has an equivalent in ddmFormViewFormInstanceRecordsDisplayContext.

This PR deviates from the ticket's suggestion to preserve the `ddmFormValues` variable. It retrieves `DDMFormValues` directly from the record version, minimizing code changes and allowing the `ddmFormValues` methods to continue being used without further change.

This decision was based on the private implementation of `_getDDMFormValues` in `DDMFormViewInstanceRecordsDispayContext.java`:

```
	private DDMFormValues _getDDMFormValues(
			DDMFormInstanceRecord ddmFormInstanceRecord)
		throws PortalException {

		DDMFormInstanceRecordVersion ddmFormInstanceRecordVersion =
			ddmFormInstanceRecord.getFormInstanceRecordVersion();

		return ddmFormInstanceRecordVersion.getDDMFormValues();
	}
```

[LPD-28870]: https://liferay.atlassian.net/browse/LPD-28870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ