### PR TITLE
LPD-101883 Add a new String parameter to the getParameterMap method of the HttpComponentsUtil class

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6059,6 +6059,14 @@
 		"to": "_sites.updateLayoutSetPrototypesLinks"
 	},
 	{
+		"classNames": [
+			"HttpComponentsUtil"
+		],
+		"from": "getParameterMap()",
+		"hasMessage": true,
+		"issueKey": "LPD-101883"
+	},
+	{
 		"from": "regex:MultiVMPoolUtil\\s*.\\s*getPortalCache\\(\\s*(?<prefixMethodName>[\\s\\S]*?)\\)",
 		"issueKey": "LPS-153962",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_101883.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_101883.testjava
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+
+/**
+ * @author Micaelle Silva
+ */
+public class LPD_101883 {
+
+	public void method() {
+		HttpComponentsUtil.getParameterMap();
+		HttpComponentsUtil.getParameterMap();
+	}
+
+}


### PR DESCRIPTION
Associated task: [LPD-101883](https://liferay.atlassian.net/browse/LPD-101883)

### What Is Being Fixed
The getParameterMap method of HttpComponentsUtil now requires a String parameter, queryString.


[LPD-101883]: https://liferay.atlassian.net/browse/LPD-101883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ