### PR TITLE
LPD-102085 Replace method name from getFile to getInputStream

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5623,6 +5623,14 @@
 		"to": "addUserWithWorkflow(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#, param#12#, param#13#, param#14#, param#15#, param#16#, param#17#, param#18#, UserConstants.TYPE_REGULAR, param#19#, param#20#, param#21#, param#22#, param#23#, param#24#)"
 	},
 	{
+		"classNames": [
+			"FileAttachment"
+		],
+		"from": "getFile()",
+		"hasMessage": true,
+		"issueKey": "LPD-61485"
+	},
+	{
 		"from": "new FileAttachment(File paramName, String paramName)",
 		"hasMessage": true,
 		"issueKey": "LPD-61487"

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61485.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61485.testjava
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Micaelle Silva
+ */
+public class LPD_61485 {
+
+	public void method(FileAttachment fileAttachment) {
+		fileAttachment.getFile();
+		fileAttachment.getFile();
+	}
+
+}


### PR DESCRIPTION
Associated task: [LPD-102085](https://liferay.atlassian.net/browse/LPD-102085)

## What Is Being Fixed
The class FileAttachment now expects an InputStream type for the second parameter instead of a String 

## How It Is Being Fixed

Added a `hasMessage` entry to `replacements.json`, scoped to the `FileAttachment` class, so any call to `getFile()` is flagged.

[LPD-102085]: https://liferay.atlassian.net/browse/LPD-102085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ