### PR TITLE
LPD-99286 Replace fileEntryId/url args on addCommerceVirtualOrderItem with CPDVirtualSettingFileEntries list

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6059,6 +6059,15 @@
 		"to": "_sites.updateLayoutSetPrototypesLinks"
 	},
 	{
+		"classNames": [
+			"CommerceVirtualOrderItemLocalService",
+			"CommerceVirtualOrderItemLocalServiceUtil"
+		],
+		"from": "regex:(?<variableName>\\w+)\\.addCommerceVirtualOrderItem\\(\\s*(?<commerceOrderItemId>\\w+),\\s*(?<cpDefinitionVirtualSettingVariableName>\\w+)\\.getFileEntryId\\(\\),\\s*\\k<cpDefinitionVirtualSettingVariableName>\\.getUrl\\(\\),\\s*(?<activationStatus>\\w+),\\s*(?<duration>\\w+),\\s*(?<maxUsages>\\w+),\\s*(?<useSample>\\w+),\\s*(?<serviceContext>\\w+)\\s*\\)",
+		"issueKey": "LPD-99286",
+		"to": "${variableName}.addCommerceVirtualOrderItem(${commerceOrderItemId}, ${cpDefinitionVirtualSettingVariableName}.getCPDVirtualSettingFileEntries(), ${activationStatus}, ${duration}, ${maxUsages}, ${serviceContext})"
+	},
+	{
 		"from": "regex:MultiVMPoolUtil\\s*.\\s*getPortalCache\\(\\s*(?<prefixMethodName>[\\s\\S]*?)\\)",
 		"issueKey": "LPS-153962",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_99286.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_99286.testjava
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Micaelle Silva
+ */
+public class LPD_99286 {
+
+	public void method(
+		long orderItemId, CPDefinitionVirtualSetting virtualSetting,
+		int activationStatus, long duration, int maxUsages, boolean useSample,
+		ServiceContext serviceContext) {
+
+		CommerceVirtualOrderItemLocalServiceUtil.addCommerceVirtualOrderItem(orderItemId, virtualSetting.getCPDVirtualSettingFileEntries(), activationStatus, duration, maxUsages, serviceContext);
+
+		_commerceVirtualOrderItemLocalService.addCommerceVirtualOrderItem(orderItemId, virtualSetting.getCPDVirtualSettingFileEntries(), activationStatus, duration, maxUsages, serviceContext);
+	}
+
+	@Reference
+	private CommerceVirtualOrderItemLocalService
+		_commerceVirtualOrderItemLocalService;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_99286.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_99286.testjava
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Micaelle Silva
+ */
+public class LPD_99286 {
+
+	public void method(
+		long orderItemId, CPDefinitionVirtualSetting virtualSetting,
+		int activationStatus, long duration, int maxUsages, boolean useSample,
+		ServiceContext serviceContext) {
+
+		CommerceVirtualOrderItemLocalServiceUtil.addCommerceVirtualOrderItem(
+			orderItemId, virtualSetting.getFileEntryId(),
+			virtualSetting.getUrl(), activationStatus, duration, maxUsages,
+			useSample, serviceContext);
+
+		_commerceVirtualOrderItemLocalService.addCommerceVirtualOrderItem(
+			orderItemId, virtualSetting.getFileEntryId(),
+			virtualSetting.getUrl(), activationStatus, duration, maxUsages,
+			useSample, serviceContext);
+	}
+
+	@Reference
+	private CommerceVirtualOrderItemLocalService
+		_commerceVirtualOrderItemLocalService;
+
+}


### PR DESCRIPTION
Associated task: [LPD-99286](https://liferay.atlassian.net/browse/LPD-99286)

## What Is Being Fixed
On 2026.q1.10-lts, `addCommerceVirtualOrderItem` moved from a per-call `(long fileEntryId, String url)` pair to a list-based `List<CPDVirtualSettingFileEntry>` argument sourced from `cpDefinitionVirtualSetting.getCPDVirtualSettingFileEntries()` (8-arg → 6-arg).

## How It Is Being Fixed

Added a `regex` entry to `replacements.json`, scoped to the `CommerceVirtualOrderItemLocalService`/`CommerceVirtualOrderItemLocalServiceUtil` classes, so calls to `addCommerceVirtualOrderItem` using the old `fileEntryId`/`url` pair are automatically replaced with the new `getCPDVirtualSettingFileEntries()` call.

[LPD-99286]: https://liferay.atlassian.net/browse/LPD-99286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ