### PR TITLE
LPD-102912 | Migrate from the 13-arg and 14-arg addAddress methods from the AddressServices to use the 19-arg one

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6350,26 +6350,47 @@
 		"classNames": [
 			"AddressLocalService",
 			"AddressLocalServiceUtil",
-			"AddressService",
-			"AddressServiceUtil"
+			"AddressLocalServiceWrapper"
 		],
 		"from": "addAddress(long paramName, String paramName, long paramName, String paramName, String paramName, String paramName, String paramName, String paramName, long paramName, long paramName, long paramName, boolean paramName, boolean paramName)",
 		"issueKey": "LPS-193462",
 		"newImports": [
 			"com.liferay.portal.kernel.service.ServiceContextThreadLocal"
 		],
-		"to": "addAddress(null, param#0#, param#1#, param#2#, null, null, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#, param#12#, null, ServiceContextThreadLocal.getServiceContext())"
+		"to": "addAddress(null, param#0#, param#1#, param#2#, param#9#, param#10#, param#8#, param#6#, null, param#11#, null, param#12#, param#3#, param#4#, param#5#, null, param#7#, null, ServiceContextThreadLocal.getServiceContext())"
 	},
 	{
 		"classNames": [
 			"AddressLocalService",
 			"AddressLocalServiceUtil",
-			"AddressService",
-			"AddressServiceUtil"
+			"AddressLocalServiceWrapper"
 		],
 		"from": "addAddress(long paramName, String paramName, long paramName, String paramName, String paramName, String paramName, String paramName, String paramName, long paramName, long paramName, long paramName, boolean paramName, boolean paramName, ServiceContext paramName)",
 		"issueKey": "LPS-193462",
-		"to": "addAddress(null, param#0#, param#1#, param#2#, null, null, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#, param#12#, null, param#13#)"
+		"to": "addAddress(null, param#0#, param#1#, param#2#, param#9#, param#10#, param#8#, param#6#, null, param#11#, null, param#12#, param#3#, param#4#, param#5#, null, param#7#, null, param#13#)"
+	},
+	{
+		"classNames": [
+			"AddressService",
+			"AddressServiceUtil",
+			"AddressServiceWrapper"
+		],
+		"from": "addAddress(String paramName, long paramName, String paramName, String paramName, String paramName, String paramName, String paramName, long paramName, long paramName, long paramName, boolean paramName, boolean paramName)",
+		"issueKey": "LPS-193462",
+		"newImports": [
+			"com.liferay.portal.kernel.service.ServiceContextThreadLocal"
+		],
+		"to": "addAddress(null, param#0#, param#1#, param#8#, param#9#, param#7#, param#5#, null, param#10#, null, param#11#, param#2#, param#3#, param#4#, null, param#6#, null, ServiceContextThreadLocal.getServiceContext())"
+	},
+	{
+		"classNames": [
+			"AddressService",
+			"AddressServiceUtil",
+			"AddressServiceWrapper"
+		],
+		"from": "addAddress(String paramName, long paramName, String paramName, String paramName, String paramName, String paramName, String paramName, long paramName, long paramName, long paramName, boolean paramName, boolean paramName, ServiceContext paramName)",
+		"issueKey": "LPS-193462",
+		"to": "addAddress(null, param#0#, param#1#, param#8#, param#9#, param#7#, param#5#, null, param#10#, null, param#11#, param#2#, param#3#, param#4#, null, param#6#, null, param#12#)"
 	},
 	{
 		"classNames": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPS_193462.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPS_193462.testjava
@@ -19,13 +19,12 @@ public class LPS_193462 {
 		String street2, String street3, String city, String zip, long regionId,
 		long countryId, long typeId, boolean mailing, boolean primary) {
 
-		AddressLocalServiceUtil.addAddress(null, userId, className, classPK, null, null, street1, street2, street3, city, zip, regionId, countryId, typeId, mailing, primary, null, ServiceContextThreadLocal.getServiceContext());
-		AddressServiceUtil.addAddress(
-			123, "test123", classPK, street1, street2, street3, city, zip,
+		AddressLocalServiceUtil.addAddress(
+			123, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary);
-		AddressServiceUtil.addAddress(null, userId, className, classPK, null, null, street1, street2, street3, city, zip, regionId, countryId, typeId, mailing, primary, null, ServiceContextThreadLocal.getServiceContext());
-		_addressLocalService.addAddress(null, userId, className, classPK, null, null, street1, street2, street3, city, zip, regionId, countryId, typeId, mailing, primary, null, ServiceContextThreadLocal.getServiceContext());
-		_addressService.addAddress(null, userId, className, classPK, null, null, street1, street2, street3, city, zip, regionId, countryId, typeId, mailing, primary, null, ServiceContextThreadLocal.getServiceContext());
+		AddressLocalServiceUtil.addAddress(null, userId, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, ServiceContextThreadLocal.getServiceContext());
+		_addressLocalService.addAddress(null, userId, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, ServiceContextThreadLocal.getServiceContext());
+		_addressLocalServiceWrapper.addAddress(null, userId, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, ServiceContextThreadLocal.getServiceContext());
 	}
 
 	public void method(
@@ -34,19 +33,49 @@ public class LPS_193462 {
 		long countryId, long typeId, boolean mailing, boolean primary,
 		ServiceContext serviceContext) {
 
-		AddressLocalServiceUtil.addAddress(null, userId, className, classPK, null, null, street1, street2, street3, city, zip, regionId, countryId, typeId, mailing, primary, null, serviceContext);
-		AddressServiceUtil.addAddress(
-			userId, "test123", 123, street1, street2, street3, city, zip,
+		AddressLocalServiceUtil.addAddress(
+			123, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary, serviceContext);
-		AddressServiceUtil.addAddress(null, userId, className, classPK, null, null, street1, street2, street3, city, zip, regionId, countryId, typeId, mailing, primary, null, serviceContext);
-		_addressLocalService.addAddress(null, userId, className, classPK, null, null, street1, street2, street3, city, zip, regionId, countryId, typeId, mailing, primary, null, serviceContext);
-		_addressService.addAddress(null, userId, className, classPK, null, null, street1, street2, street3, city, zip, regionId, countryId, typeId, mailing, primary, null, serviceContext);
+		AddressLocalServiceUtil.addAddress(null, userId, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, serviceContext);
+		_addressLocalService.addAddress(null, userId, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, serviceContext);
+		_addressLocalServiceWrapper.addAddress(null, userId, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, serviceContext);
+	}
+
+	public void method(
+		String className, long classPK, String street1, String street2,
+		String street3, String city, String zip, long regionId, long countryId,
+		long typeId, boolean mailing, boolean primary) {
+
+		AddressServiceUtil.addAddress(
+			"test123", classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary);
+		AddressServiceUtil.addAddress(null, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, ServiceContextThreadLocal.getServiceContext());
+		_addressService.addAddress(null, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, ServiceContextThreadLocal.getServiceContext());
+		_addressServiceWrapper.addAddress(null, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, ServiceContextThreadLocal.getServiceContext());
+	}
+
+	public void method(
+		String className, long classPK, String street1, String street2,
+		String street3, String city, String zip, long regionId, long countryId,
+		long typeId, boolean mailing, boolean primary,
+		ServiceContext serviceContext) {
+
+		AddressServiceUtil.addAddress(
+			"test123", classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary, serviceContext);
+		AddressServiceUtil.addAddress(null, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, serviceContext);
+		_addressService.addAddress(null, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, serviceContext);
+		_addressServiceWrapper.addAddress(null, className, classPK, countryId, typeId, regionId, city, null, mailing, null, primary, street1, street2, street3, null, zip, null, serviceContext);
 	}
 
 	@Reference
 	private AddressLocalService _addressLocalService;
 
+	private AddressLocalServiceWrapper _addressLocalServiceWrapper;
+
 	@Reference
 	private AddressService _addressService;
+
+	private AddressServiceWrapper _addressServiceWrapper;
 
 }

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPS_193462.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPS_193462.testjava
@@ -18,18 +18,15 @@ public class LPS_193462 {
 		long countryId, long typeId, boolean mailing, boolean primary) {
 
 		AddressLocalServiceUtil.addAddress(
-			userId, className, classPK, street1, street2, street3, city, zip,
+			123, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary);
-		AddressServiceUtil.addAddress(
-			123, "test123", classPK, street1, street2, street3, city, zip,
-			regionId, countryId, typeId, mailing, primary);
-		AddressServiceUtil.addAddress(
+		AddressLocalServiceUtil.addAddress(
 			userId, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary);
 		_addressLocalService.addAddress(
 			userId, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary);
-		_addressService.addAddress(
+		_addressLocalServiceWrapper.addAddress(
 			userId, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary);
 	}
@@ -41,26 +38,66 @@ public class LPS_193462 {
 		ServiceContext serviceContext) {
 
 		AddressLocalServiceUtil.addAddress(
-			userId, className, classPK, street1, street2, street3, city, zip,
+			123, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary, serviceContext);
-		AddressServiceUtil.addAddress(
-			userId, "test123", 123, street1, street2, street3, city, zip,
-			regionId, countryId, typeId, mailing, primary, serviceContext);
-		AddressServiceUtil.addAddress(
+		AddressLocalServiceUtil.addAddress(
 			userId, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary, serviceContext);
 		_addressLocalService.addAddress(
 			userId, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary, serviceContext);
-		_addressService.addAddress(
+		_addressLocalServiceWrapper.addAddress(
 			userId, className, classPK, street1, street2, street3, city, zip,
 			regionId, countryId, typeId, mailing, primary, serviceContext);
+	}
+
+	public void method(
+		String className, long classPK, String street1, String street2,
+		String street3, String city, String zip, long regionId, long countryId,
+		long typeId, boolean mailing, boolean primary) {
+
+		AddressServiceUtil.addAddress(
+			"test123", classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary);
+		AddressServiceUtil.addAddress(
+			className, classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary);
+		_addressService.addAddress(
+			className, classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary);
+		_addressServiceWrapper.addAddress(
+			className, classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary);
+	}
+
+	public void method(
+		String className, long classPK, String street1, String street2,
+		String street3, String city, String zip, long regionId, long countryId,
+		long typeId, boolean mailing, boolean primary,
+		ServiceContext serviceContext) {
+
+		AddressServiceUtil.addAddress(
+			"test123", classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary, serviceContext);
+		AddressServiceUtil.addAddress(
+			className, classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary, serviceContext);
+		_addressService.addAddress(
+			className, classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary, serviceContext);
+		_addressServiceWrapper.addAddress(
+			className, classPK, street1, street2, street3, city, zip, regionId,
+			countryId, typeId, mailing, primary, serviceContext);
 	}
 
 	@Reference
 	private AddressLocalService _addressLocalService;
 
+	private AddressLocalServiceWrapper _addressLocalServiceWrapper;
+
 	@Reference
 	private AddressService _addressService;
+
+	private AddressServiceWrapper _addressServiceWrapper;
 
 }


### PR DESCRIPTION
Ticket: [LPD-102912](https://liferay.atlassian.net/browse/LPD-102912?atlOrigin=eyJpIjoiNDAxNDhiNTg0YzA4NDBhYWI5NWZjZDNmODU1NGM2NzEiLCJwIjoiaiJ9)

The old automation did not have all the new parameters and it also used the same case for the Local and not Local class (They both checked the userId parameter).

[LPD-102912]: https://liferay.atlassian.net/browse/LPD-102912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ