### PR TITLE
LPD-103276 | CommerceOrderLocalService.updateCommerceOrder 13-arg overload: insert null name at position 8 and drop trailing commerce context

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6059,6 +6059,19 @@
 		"to": "_sites.updateLayoutSetPrototypesLinks"
 	},
 	{
+		"classNames": [
+			"CommerceOrderLocalService",
+			"CommerceOrderLocalServiceUtil",
+			"CommerceOrderLocalServiceWrapper",
+			"CommerceOrderService",
+			"CommerceOrderServiceUtil",
+			"CommerceOrderServiceWrapper"
+		],
+		"from": "updateCommerceOrder(String paramName, long paramName, long paramName, long paramName, long paramName, String paramName, String paramName, String paramName, BigDecimal paramName, String paramName, BigDecimal paramName, BigDecimal paramName, CommerceContext paramName)",
+		"issueKey": "LPD-103276",
+		"to": "updateCommerceOrder(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, param#6#, null, param#7#, param#8#, param#9#, param#10#, param#11#)"
+	},
+	{
 		"from": "regex:MultiVMPoolUtil\\s*.\\s*getPortalCache\\(\\s*(?<prefixMethodName>[\\s\\S]*?)\\)",
 		"issueKey": "LPS-153962",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_103276.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_103276.testjava
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_103276 {
+
+	public void method(
+		String externalReferenceCode, long commerceOrderId,
+		long billingAddressId, long commerceShippingMethodId,
+		long shippingAddressId, String advanceStatus,
+		String commercePaymentMethodKey, String purchaseOrderNumber,
+		BigDecimal shippingAmount, String shippingOptionName,
+		BigDecimal subtotal, BigDecimal total,
+		CommerceContext commerceContext) {
+
+		CommerceOrderLocalServiceUtil.updateCommerceOrder(
+			"test123", commerceOrderId, billingAddressId,
+			commerceShippingMethodId, shippingAddressId, advanceStatus,
+			commercePaymentMethodKey, purchaseOrderNumber, shippingAmount,
+			shippingOptionName, subtotal, total, commerceContext);
+		CommerceOrderLocalServiceUtil.updateCommerceOrder(externalReferenceCode, commerceOrderId, billingAddressId, commerceShippingMethodId, shippingAddressId, advanceStatus, commercePaymentMethodKey, null, purchaseOrderNumber, shippingAmount, shippingOptionName, subtotal, total);
+		CommerceOrderServiceUtil.updateCommerceOrder(externalReferenceCode, commerceOrderId, billingAddressId, commerceShippingMethodId, shippingAddressId, advanceStatus, commercePaymentMethodKey, null, purchaseOrderNumber, shippingAmount, shippingOptionName, subtotal, total);
+		_commerceOrderLocalService.updateCommerceOrder(externalReferenceCode, commerceOrderId, billingAddressId, commerceShippingMethodId, shippingAddressId, advanceStatus, commercePaymentMethodKey, null, purchaseOrderNumber, shippingAmount, shippingOptionName, subtotal, total);
+		_commerceOrderLocalServiceWrapper.updateCommerceOrder(externalReferenceCode, commerceOrderId, billingAddressId, commerceShippingMethodId, shippingAddressId, advanceStatus, commercePaymentMethodKey, null, purchaseOrderNumber, shippingAmount, shippingOptionName, subtotal, total);
+		_commerceOrderService.updateCommerceOrder(externalReferenceCode, commerceOrderId, billingAddressId, commerceShippingMethodId, shippingAddressId, advanceStatus, commercePaymentMethodKey, null, purchaseOrderNumber, shippingAmount, shippingOptionName, subtotal, total);
+		_commerceOrderServiceWrapper.updateCommerceOrder(externalReferenceCode, commerceOrderId, billingAddressId, commerceShippingMethodId, shippingAddressId, advanceStatus, commercePaymentMethodKey, null, purchaseOrderNumber, shippingAmount, shippingOptionName, subtotal, total);
+	}
+
+	@Reference
+	private CommerceOrderLocalService _commerceOrderLocalService;
+
+	private CommerceOrderLocalServiceWrapper _commerceOrderLocalServiceWrapper;
+
+	@Reference
+	private CommerceOrderService _commerceOrderService;
+
+	private CommerceOrderServiceWrapper _commerceOrderServiceWrapper;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_103276.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_103276.testjava
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_103276 {
+
+	public void method(
+		String externalReferenceCode, long commerceOrderId,
+		long billingAddressId, long commerceShippingMethodId,
+		long shippingAddressId, String advanceStatus,
+		String commercePaymentMethodKey, String purchaseOrderNumber,
+		BigDecimal shippingAmount, String shippingOptionName,
+		BigDecimal subtotal, BigDecimal total,
+		CommerceContext commerceContext) {
+
+		CommerceOrderLocalServiceUtil.updateCommerceOrder(
+			"test123", commerceOrderId, billingAddressId,
+			commerceShippingMethodId, shippingAddressId, advanceStatus,
+			commercePaymentMethodKey, purchaseOrderNumber, shippingAmount,
+			shippingOptionName, subtotal, total, commerceContext);
+		CommerceOrderLocalServiceUtil.updateCommerceOrder(
+			externalReferenceCode, commerceOrderId, billingAddressId,
+			commerceShippingMethodId, shippingAddressId, advanceStatus,
+			commercePaymentMethodKey, purchaseOrderNumber, shippingAmount,
+			shippingOptionName, subtotal, total, commerceContext);
+		CommerceOrderServiceUtil.updateCommerceOrder(
+			externalReferenceCode, commerceOrderId, billingAddressId,
+			commerceShippingMethodId, shippingAddressId, advanceStatus,
+			commercePaymentMethodKey, purchaseOrderNumber, shippingAmount,
+			shippingOptionName, subtotal, total, commerceContext);
+		_commerceOrderLocalService.updateCommerceOrder(
+			externalReferenceCode, commerceOrderId, billingAddressId,
+			commerceShippingMethodId, shippingAddressId, advanceStatus,
+			commercePaymentMethodKey, purchaseOrderNumber, shippingAmount,
+			shippingOptionName, subtotal, total, commerceContext);
+		_commerceOrderLocalServiceWrapper.updateCommerceOrder(
+			externalReferenceCode, commerceOrderId, billingAddressId,
+			commerceShippingMethodId, shippingAddressId, advanceStatus,
+			commercePaymentMethodKey, purchaseOrderNumber, shippingAmount,
+			shippingOptionName, subtotal, total, commerceContext);
+		_commerceOrderService.updateCommerceOrder(
+			externalReferenceCode, commerceOrderId, billingAddressId,
+			commerceShippingMethodId, shippingAddressId, advanceStatus,
+			commercePaymentMethodKey, purchaseOrderNumber, shippingAmount,
+			shippingOptionName, subtotal, total, commerceContext);
+		_commerceOrderServiceWrapper.updateCommerceOrder(
+			externalReferenceCode, commerceOrderId, billingAddressId,
+			commerceShippingMethodId, shippingAddressId, advanceStatus,
+			commercePaymentMethodKey, purchaseOrderNumber, shippingAmount,
+			shippingOptionName, subtotal, total, commerceContext);
+	}
+
+	@Reference
+	private CommerceOrderLocalService _commerceOrderLocalService;
+
+	private CommerceOrderLocalServiceWrapper _commerceOrderLocalServiceWrapper;
+
+	@Reference
+	private CommerceOrderService _commerceOrderService;
+
+	private CommerceOrderServiceWrapper _commerceOrderServiceWrapper;
+
+}


### PR DESCRIPTION
Ticket [LPD-103276](https://liferay.atlassian.net/browse/LPD-103276?atlOrigin=eyJpIjoiZTg0YTM4OTJjNGExNGNiNmJlZjYwMGYwMmEyNGE3NzUiLCJwIjoiaiJ9)

[LPD-103276]: https://liferay.atlassian.net/browse/LPD-103276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ