### PR TITLE
LPD-99284 | Migrate the 3-arg LayoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry call to the 4-arg overload with layoutPageTemplateCollectionId | Java Files

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6046,6 +6046,15 @@
 		"to": "_sites.updateLayoutSetPrototypesLinks"
 	},
 	{
+		"classNames": [
+			"LayoutPageTemplateEntryLocalService",
+			"LayoutPageTemplateEntryLocalServiceUtil"
+		],
+		"from": "fetchLayoutPageTemplateEntry(long paramName, String paramName, int paramName)",
+		"issueKey": "LPD-99284",
+		"to": "fetchLayoutPageTemplateEntry(param#0#, 0L, param#1#, param#2#)"
+	},
+	{
 		"from": "regex:MultiVMPoolUtil\\s*.\\s*getPortalCache\\(\\s*(?<prefixMethodName>[\\s\\S]*?)\\)",
 		"issueKey": "LPS-153962",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_99284.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_99284.testjava
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Liferay
+ */
+public class LPD_99284 {
+
+	public void method(long groupId, String name, int type) {
+		LayoutPageTemplateEntryLocalServiceUtil.fetchLayoutPageTemplateEntry(
+			123, name, type);
+		LayoutPageTemplateEntryLocalServiceUtil.fetchLayoutPageTemplateEntry(groupId, 0L, name, type);
+		_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(groupId, 0L, name, type);
+	}
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_99284.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_99284.testjava
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Liferay
+ */
+public class LPD_99284 {
+
+	public void method(long groupId, String name, int type) {
+		LayoutPageTemplateEntryLocalServiceUtil.fetchLayoutPageTemplateEntry(
+			123, name, type);
+		LayoutPageTemplateEntryLocalServiceUtil.fetchLayoutPageTemplateEntry(
+			groupId, name, type);
+		_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(
+			groupId, name, type);
+	}
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+}


### PR DESCRIPTION
[LPD-99284](https://liferay.atlassian.net/browse/LPD-99284)

[LPD-99284]: https://liferay.atlassian.net/browse/LPD-99284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ